### PR TITLE
Fix #20: GlyphView clips some 'tall' Glyphs.

### DIFF
--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -34,6 +34,14 @@ internal sealed class MainViewModel : ObservableObject
 
     #region Properties
 
+    /// <summary>
+    /// Gets the preferred size of the GlyphView width.
+    /// </summary>
+    public double GlyphWidth
+    {
+        get => 300;
+    }
+
     #region Rows
 
     /// <summary>
@@ -204,6 +212,8 @@ internal sealed class MainViewModel : ObservableObject
 
     #endregion Selected Glyph Properties
 
+    #region Family Group
+
     /// <summary>
     /// Gets or sets the command for the jump list to pick a font family group.
     /// </summary>
@@ -233,6 +243,8 @@ internal sealed class MainViewModel : ObservableObject
             }
         }
     }
+
+    #endregion Family Group
 
     #region Unicode Range Properties
 

--- a/Views/MainPage.xaml
+++ b/Views/MainPage.xaml
@@ -73,15 +73,11 @@
                                  BackgroundColor="{AppThemeBinding Light={StaticResource PrimaryDarkText}, Dark=WhiteSmoke}"
                                  LineColor="{AppThemeBinding Light=Tomato, Dark=Red}"
                                  BaselineColor="{AppThemeBinding Light=LightGreen, Dark=Green}"
-                                 MinimumHeightRequest="300"
-                                 MinimumWidthRequest="300"
-                                 x:Name="Glyphs"
+                                 MinimumWidthRequest="{Binding GlyphWidth}"
                                  />
 
-                <!-- NOTE: WidthRequest ensures the view doesn't resize when properties change -->
-                <views:MetricsView Grid.Row="2" 
-                                   WidthRequest="{Binding Width, Source={x:Reference Glyphs}, x:DataType=views:GlyphView}"
-                                   />
+                <!-- NOTE: WidthRequest ensures the view width doesn't resize when properties change -->
+                <views:MetricsView Grid.Row="2" WidthRequest="{Binding GlyphWidth}"/>
 
             </Grid>
         </Grid>


### PR DESCRIPTION
MainViewModel.cs:
- Define a property for the preferred width of the GlyphView

GlyphView.cs
- Calculate the glyph metrics when the typeface changes
- Override MeasureOverride to set the height based on the glyph metrics and cache the SKFont.
- Remove unneeded custom DrawLine method

MainPage.xaml
- Remove MinimumHeightRequest from GlyphView
- Bind GlyphView and MetricsView MinimumWidthRequest to MainViewModel.GlyphWidth
- Bind