### PR TITLE
Fix #28: Restore selected font when returning from the SettingsPage

### DIFF
--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -138,13 +138,7 @@ internal sealed class MainViewModel : ObservableObject
     public GlyphCollection Glyphs
     {
         get => _glyphs;
-        private set
-        {
-            if (SetProperty(ref _glyphs, value, ReferenceComparer, GlyphsChangedEventArgs))
-            {
-                // _metrics.Glyph = Glyph.Empty;
-            }
-        }
+        private set => SetProperty(ref _glyphs, value, ReferenceComparer, GlyphsChangedEventArgs);
     }
 
     #endregion Glyphs

--- a/Views/MainPage.xaml.cs
+++ b/Views/MainPage.xaml.cs
@@ -15,6 +15,9 @@ public partial class MainPage : ContentPage
     protected override void OnNavigatedTo(NavigatedToEventArgs args)
     {
         base.OnNavigatedTo(args);
-        Task.Run(() => { _model.LoadFonts(Dispatcher); });
+        if (_model.Glyphs is null)
+        {
+            Task.Run(() => { _model.LoadFonts(Dispatcher); });
+        }
     }
 }


### PR DESCRIPTION
MainPage was loading font families unconditionally in OnNavigated cause the selected FontFamily and Glyph to be cleared. Update to only load glyphs if the MainViewModel.Glyphs is null (i.e. on first call)

MainViewModel: Remove commented out code in Glyphs property setter.