### PR TITLE
Fix #34: Redundant style settings in GlyphButtonStyle

### DIFF
--- a/Resources/Styles/Styles.xaml
+++ b/Resources/Styles/Styles.xaml
@@ -4,6 +4,7 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:controls="clr-namespace:GlyphViewer.Controls"
+    xmlns:objectmodel="clr-namespace:GlyphViewer.ObjectModel"
     xmlns:text="clr-namespace:GlyphViewer.Text"
     >
 
@@ -32,8 +33,7 @@
                     <VisualState x:Name="Normal" />
                     <VisualState x:Name="PointerOver">
                         <VisualState.Setters>
-                            <Setter Property="BackgroundColor"
-                                       Value="SkyBlue" />
+                            <Setter Property="BackgroundColor" Value="DarkTurquoise" />
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>
@@ -106,8 +106,6 @@
     <!-- #endregion NamedValue -->
 
     <Style TargetType="Button" x:Key="GlyphButtonStyle">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource PrimaryDarkText}, Dark=WhiteSmoke}"/>
-        <Setter Property="BackgroundColor" Value="Transparent"/>
         <Setter Property="FontFamily" Value="FluentUI"/>
         <Setter Property="FontSize" Value="30"/>
         <Setter Property="FontAttributes" Value="Bold"/>
@@ -139,9 +137,10 @@
         <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray950}, Dark={StaticResource Gray200}}" />
     </Style>
 
-    <Style TargetType="Button">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource PrimaryDarkText}}" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+    <Style TargetType="Button"
+           ApplyToDerivedTypes="true">
+        <Setter Property="TextColor" Value="{AppThemeBinding Dark=WhiteSmoke, Light={StaticResource PrimaryDarkText}}" />
+        <Setter Property="BackgroundColor" Value="Transparent" />
         <Setter Property="FontFamily" Value="OpenSansRegular"/>
         <Setter Property="FontSize" Value="14"/>
         <Setter Property="BorderWidth" Value="0"/>
@@ -156,10 +155,14 @@
                     <VisualState x:Name="Disabled">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray950}, Dark={StaticResource Gray200}}" />
-                            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray600}}" />
                         </VisualState.Setters>
                     </VisualState>
-                    <VisualState x:Name="PointerOver" />
+                    <VisualState x:Name="PointerOver">
+                        <VisualState.Setters>
+                            <Setter Property="BackgroundColor" Value="DarkTurquoise"/>
+                            <Setter Property="BorderWidth" Value="0"/>
+                        </VisualState.Setters>
+                    </VisualState>
                 </VisualStateGroup>
             </VisualStateGroupList>
         </Setter>


### PR DESCRIPTION
Button Style
- Enable PointerHover color for buttons
- Set ApplyToDerivedTypes = true GlyphButtonStyle
- Remove duplicate setters