### PR TITLE
Support Bookmarks and change Settings persistence to JSON settings file.

### DIFF
--- a/Converter/JsonConverter.cs
+++ b/Converter/JsonConverter.cs
@@ -1,0 +1,70 @@
+﻿namespace GlyphViewer.Converter;
+
+using System.Text.Json;
+
+/// <summary>
+/// Provides a base <see cref="System.Text.Json.Serialization.JsonConverter{T}"/> with read and verify methods.
+/// </summary>
+/// <typeparam name="T">The type of object to convert.</typeparam>
+public abstract class JsonConverter<T> : System.Text.Json.Serialization.JsonConverter<T>
+{
+    #region Read
+
+    /// <summary>
+    /// Reads and converts the JSON to a <typeparamref name="T"/> instance.
+    /// </summary>
+    /// <param name="reader">The <see cref="Utf8JsonReader"/> to read.</param>
+    /// <param name="typeToConvert">The type to convert.
+    /// <para>
+    /// The implementation expects the type <typeparamref name="T"/>.
+    /// </para>.
+    /// </param>
+    /// <param name="options">The <see cref="JsonSerializerOptions"/> to use to deserialize.</param>
+    /// <returns>An instance of a <paramref name="typeToConvert"/>.</returns>
+    /// <exception cref="ArgumentException"><paramref name="reader"/> is using unsupported options.</exception>
+    /// <exception cref="ArgumentException"><paramref name="typeToConvert"/> must be of type <typeparamref name="T"/>.</exception>
+    public override sealed T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (typeToConvert != typeof(T) && !typeToConvert.IsSubclassOf(typeof(T)))
+        {
+            throw new ArgumentException(nameof(typeToConvert));
+        }
+        return OnRead(ref reader, options);
+    }
+
+    /// <summary>
+    /// Implemented in the derived class to read the <typeparamref name="T"/> object.
+    /// </summary>
+    /// <param name="reader">The <see cref="Utf8JsonReader"/> to read.</param>
+    /// <returns>An instance of a <typeparamref name="T"/>.</returns>
+    protected abstract T OnRead(ref Utf8JsonReader reader, JsonSerializerOptions options);
+
+    #endregion Read
+
+    #region Write
+
+    /// <summary>
+    /// Writes a specified value as JSON.
+    /// </summary>
+    /// <param name="writer">The writer to write to.</param>
+    /// <param name="value">The <typeparamref name="T"/> value to convert to JSON.</param>
+    /// <param name="options">An object that specifies serialization options to use.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="writer"/> or <paramref name="value"/> is a null reference.</exception>
+    public override sealed void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(options);
+
+        OnWrite(writer, value, options);
+    }
+
+    /// <summary>
+    /// Implemented in the derived class to write the <paramref name="value"/> to the <paramref name="writer"/>.
+    /// </summary>
+    /// <param name="writer">The writer to write to.</param>
+    /// <param name="value">The <typeparamref name="T"/> value to write.</param>
+    protected abstract void OnWrite(Utf8JsonWriter writer, T value, JsonSerializerOptions options);
+
+    #endregion Write
+}

--- a/Converter/JsonExtensions.cs
+++ b/Converter/JsonExtensions.cs
@@ -1,0 +1,126 @@
+﻿namespace GlyphViewer.Converter;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Provides <see cref="System.Text.Json"/> extension methods.
+/// </summary>
+public static class JsonExtensions
+{
+    #region Read
+
+    /// <summary>
+    /// Reads the next token
+    /// </summary>
+    /// <param name="reader">The <see cref="Utf8JsonReader"/> to read.</param>
+    /// <param name="expectedToken">The expected <see cref="JsonTokenType"/>.</param>
+    /// <remarks>
+    /// This method is used to verify and read various tokens
+    /// such as <see cref="JsonTokenType.StartArray"/> and <see cref="JsonTokenType.EndObject"/>.
+    /// </remarks>
+    static public void Read(ref this Utf8JsonReader reader, JsonTokenType expectedToken)
+    {
+        Verify(reader, expectedToken);
+        reader.Read();
+    }
+
+    /// <summary>
+    /// Reads and returns a property name from the <paramref name="reader"/>.
+    /// </summary>
+    /// <param name="reader">The <see cref="Utf8JsonReader"/> to read.</param>
+    /// <returns>The property name read from the reader.</returns>
+    /// <exception cref="JsonException">The value of <see cref="Utf8JsonReader.TokenType"/> is not <see cref="JsonTokenType.PropertyName"/>.</exception>
+    public static string ReadPropertyName(this ref Utf8JsonReader reader)
+    {
+        reader.Verify(JsonTokenType.PropertyName);
+        string propertyName = reader.GetString();
+        reader.Read();
+        return propertyName;
+    }
+
+    #endregion Read
+
+    #region Add
+
+    /// <summary>
+    /// Adds one or more <see cref="JsonConverter"/> elements to <see cref="JsonSerializerOptions.Converters"/>.
+    /// </summary>
+    /// <param name="options">The <see cref="JsonSerializerOptions"/> to update.</param>
+    /// <param name="converters">The <see cref="IEnumerable{JsonConverter}"/> of
+    /// the converters to add.</param>
+    public static void Add
+    (
+        this JsonSerializerOptions options,
+        params JsonConverter[] converters
+    )
+    {
+        foreach (JsonConverter converter in converters)
+        {
+            options.Converters.Add(converter);
+        }
+    }
+
+    #endregion Add
+
+    #region Verify
+
+    /// <summary>
+    /// Verifies the current token is the expected type.
+    /// </summary>
+    /// <param name="reader"></param>
+    /// <param name="expected"></param>
+    /// <exception cref="JsonException">The value of <see cref="Utf8JsonReader.TokenType"/> is does not match the <paramref name="expected"/>.</exception>
+    public static void Verify(this Utf8JsonReader reader, JsonTokenType expected)
+    {
+        if (reader.TokenType != expected)
+        {
+            reader.Unexpected(expected);
+        }
+    }
+
+    #endregion Verify
+
+    #region Unexpected
+
+    /// <summary>
+    /// Throws a <see cref="JsonException"/> for the unexpected <see cref="JsonTokenType"/>.
+    /// </summary>
+    /// <param name="reader">The <see cref="Utf8JsonReader"/> being read.</param>
+    /// <param name="expected">The expected <see cref="JsonTokenType"/>.</param>
+    /// <exception cref="JsonException">The value of <see cref="Utf8JsonReader.TokenType"/> is does not match the <paramref name="expected"/>.</exception>
+    public static void Unexpected(this Utf8JsonReader reader, JsonTokenType expected)
+    {
+        throw new JsonException
+        (
+            string.Format
+            (
+                "Unexpected token {0} at {1}. {2} Expected",
+                reader.TokenType,
+                reader.TokenStartIndex,
+                expected
+            )
+        );
+    }
+
+   #endregion Unexpected
+
+    #region InvalidValue
+
+    /// <summary>
+    /// Throws a <see cref="JsonException"/> when an invalid value.
+    /// </summary>
+    /// <param name="tokenType">The <see cref="JsonTokenType"/> being read.</param>
+    /// <param name="name">The name of the token.</param>
+    /// <param name="value">The property value that was read.</param>
+    /// <exception cref="JsonException">The value of property is not valid.</exception>
+    public static void InvalidValue(this Utf8JsonReader reader, JsonTokenType tokenType, string name, string value)
+    {
+        throw new JsonException
+        (
+            string.Format("Unexpected value for {0} {1} at {2}:{3}.", tokenType, name, reader.TokenStartIndex, value)
+        );
+    }
+
+    #endregion InvalidValue
+}

--- a/Converter/UserSettingsJsonConverter.cs
+++ b/Converter/UserSettingsJsonConverter.cs
@@ -1,0 +1,98 @@
+﻿namespace GlyphViewer.Converter;
+
+using GlyphViewer.Settings;
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Provides a <see cref="JsonConverter{UserSettings}"/>.
+/// </summary>
+internal class UserSettingsJsonConverter : JsonConverter<UserSettings>
+{
+    /// <summary>
+    /// Provides the <see cref="JsonSerializerOptions"/> to use with this converter.
+    /// </summary>
+    public static readonly JsonSerializerOptions Options;
+
+    /// <summary>
+    /// Provides a singleton <see cref="UserSettingsJsonConverter"/> instance.
+    /// </summary>
+    public static readonly UserSettingsJsonConverter Converter = new();
+
+    static UserSettingsJsonConverter()
+    {
+        Options = new()
+        {
+            WriteIndented = true,
+            IgnoreReadOnlyFields = true,
+            IgnoreReadOnlyProperties = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            IncludeFields = false,
+            NumberHandling = JsonNumberHandling.AllowReadingFromString,
+            PropertyNameCaseInsensitive = false,
+            ReadCommentHandling = JsonCommentHandling.Skip
+        };
+        Options.Add
+        (
+            new UserSettingsJsonConverter()
+        );
+    }
+
+    private UserSettingsJsonConverter()
+    {
+    }
+
+    /// <summary>
+    /// Reads the <see cref="UserSettings"/> from the <paramref name="reader"/>.
+    /// </summary>
+    /// <param name="reader">The <see cref="Utf8JsonReader"/> to read.</param>
+    /// <param name="options">The <see cref="JsonSerializerOptions"/> to use to control serialization.</param>
+    /// <returns>A new instance of a <see cref="UserSettings"/>.</returns>
+    protected override UserSettings OnRead(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        UserSettings settings = new();
+
+        reader.Read(JsonTokenType.StartObject);
+        while (reader.TokenType != JsonTokenType.EndObject)
+        {
+            string propertyName = reader.ReadPropertyName();
+            ISetting setting = settings[propertyName];
+            if (setting is not null)
+            {
+                setting.ReadValue(ref reader, options);
+                reader.Read();
+            }
+            else
+            {
+                // NOTE: Unknown property, skip it.
+                Trace.WriteLine($"Skipping unknown property '{propertyName}'");
+                reader.Skip();
+            }
+        }
+        reader.Verify(JsonTokenType.EndObject);
+        return settings;
+    }
+
+    /// <summary>
+    /// Writes the <see cref="UserSettings"/> to the <paramref name="writer"/>.
+    /// </summary>
+    /// <param name="writer">The <see cref="Utf8JsonWriter"/> to write.</param>
+    /// <param name="settings">The <see cref="UserSettings"/> to write.</param>
+    /// <param name="options">The <see cref="JsonSerializerOptions"/> to use to control serialization.</param>
+    protected override void OnWrite(Utf8JsonWriter writer, UserSettings settings, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+
+        foreach (ISetting setting in settings)
+        {
+            if (!setting.IsDefault)
+            {
+                writer.WritePropertyName(setting.Name);
+                setting.WriteValue(writer, options);
+            }
+        }
+
+        writer.WriteEndObject();
+    }
+}

--- a/ObjectModel/Command.cs
+++ b/ObjectModel/Command.cs
@@ -1,17 +1,25 @@
 ﻿namespace GlyphViewer.ObjectModel;
 
+using System.ComponentModel;
 using System.Windows.Input;
 
 /// <summary>
 /// Provides an <see cref="ICommand"/> implementation.
 /// </summary>
-public class Command : ICommand
+public class Command : ObservableObject, ICommand
 {
     #region Fields
 
     readonly Action _action;
     bool _isEnabled = true;
 
+
+    /// <summary>
+    /// Provides an action that does nothing.
+    /// </summary>
+    /// <remarks>
+    /// This method is used for cases where the derived class overrides <see cref="Execute"/>.
+    /// </remarks>
     protected static void NopAction()
     {
     }
@@ -39,9 +47,8 @@ public class Command : ICommand
         get => _isEnabled;
         set
         {
-            if (value != _isEnabled)
+            if (SetProperty(ref _isEnabled, value, IsEnabledChangedEventArgs))
             {
-                _isEnabled = value;
                 CanExecuteChanged?.Invoke(this, EventArgs.Empty);
             }
         }
@@ -90,4 +97,12 @@ public class Command : ICommand
 
     #endregion Methods
 
+    #region PropertyChangedEventArgs
+
+    /// <summary>
+    /// Provides <see cref="PropertyChangedEventArgs"/> when <see cref="IsEnabled"/> changes.
+    /// </summary>
+    public static readonly PropertyChangedEventArgs IsEnabledChangedEventArgs = new(nameof(IsEnabled));
+
+    #endregion PropertyChangedEventArgs
 }

--- a/ObjectModel/ObservableProperty.cs
+++ b/ObjectModel/ObservableProperty.cs
@@ -3,17 +3,17 @@
 using System.ComponentModel;
 
 /// <summary>
+/// Provides a delegate on the containing object to invoke to raise the 
+/// <see cref="INotifyPropertyChanged.PropertyChanged"/> event for the property.
+/// </summary>
+/// <param name="e">The <see cref="PropertyChangedEventArgs"/> with the event details.</param>
+public delegate void NotifyPropertyChangedDelegate(PropertyChangedEventArgs e);
+
+/// <summary>
 /// Provides an abstract base class for an observable property.
 /// </summary>
 public abstract class ObservableProperty : ObservableObject
 {
-    /// <summary>
-    /// Provides a delegate on the containing object to invoke to raise the 
-    /// <see cref="INotifyPropertyChanged.PropertyChanged"/> event for the property.
-    /// </summary>
-    /// <param name="e">The <see cref="PropertyChangedEventArgs"/> with the event details.</param>
-    public delegate void NotifyPropertyChangedDelegate(PropertyChangedEventArgs e);
-
     #region Fields
 
     readonly NotifyPropertyChangedDelegate _propertyChanged;
@@ -76,6 +76,12 @@ public abstract class ObservableProperty : ObservableObject
     }
 
     #endregion Methods
+
+    /// <summary>
+    /// Defines the <see cref="PropertyChangedEventArgs"/> passed to <see cref="INotifyPropertyChanged.PropertyChanged"/>
+    /// when the property value changes.
+    /// </summary>
+    public static readonly PropertyChangedEventArgs ValueChangedEventArgs = new("Value");
 }
 
 /// <summary>
@@ -110,7 +116,7 @@ public class ObservableProperty<T> : ObservableProperty
     /// Initializes a new instance of this class.
     /// </summary>
     /// <param name="propertyChanged">
-    /// The <see cref="ObservableProperty.NotifyPropertyChangedDelegate"/> to invoke to raise
+    /// The <see cref="NotifyPropertyChangedDelegate"/> to invoke to raise
     /// the <see cref="INotifyPropertyChanged.PropertyChanged"/> event.
     /// </param>
     /// <param name="eventArgs">The <see cref="PropertyChangedEventArgs"/> to pass to <paramref name="propertyChanged"/>.</param>
@@ -128,7 +134,7 @@ public class ObservableProperty<T> : ObservableProperty
     )
         : base(propertyChanged, eventArgs)
     {
-        _comparer = comparer;
+        _comparer = comparer ?? EqualityComparer<T>.Default;
     }
 
     #endregion Constructors
@@ -155,9 +161,13 @@ public class ObservableProperty<T> : ObservableProperty
     #endregion Properties
 
     /// <summary>
-    /// Defines the <see cref="PropertyChangedEventArgs"/> passed to <see cref="INotifyPropertyChanged.PropertyChanged"/>
-    /// when <see cref="Value"/> changes.
+    /// Compares the <see cref="Value"/> to the specified value using the <see cref="IEqualityComparer{T}"/> instance.
     /// </summary>
-    static readonly PropertyChangedEventArgs ValueChangedEventArgs = new(nameof(Value));
+    /// <param name="value">The value to compare.</param>
+    /// <returns>true if <paramref name="value"/> is equal to <see cref="Value"/>; otherwise, false.</returns>
+    protected bool AreEqual(T value)
+    {
+        return _comparer.Equals(_value, value);
+    }
 }
 

--- a/ObjectModel/OrderedList.cs
+++ b/ObjectModel/OrderedList.cs
@@ -1,0 +1,155 @@
+﻿namespace GlyphViewer.ObjectModel;
+
+using System.Collections;
+
+/// <summary>
+/// This is a placeholder class used by FontFamilyGroup to workaround https://github.com/dotnet/maui/discussions/29221
+/// </summary>
+/// <typeparam name="T">The type of item in the list.</typeparam>
+internal class OrderedList<T> : IList<T>
+{
+    private readonly IComparer<T> _comparer;
+    private readonly List<T> _items = [];
+
+    public OrderedList(IComparer<T> comparer, IEnumerable<T> colors = null)
+    {
+        _comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
+        if (colors is not null)
+        {
+            foreach (T color in colors)
+            {
+                AddItem(color);
+            }
+        }
+    }
+
+    #region Properties
+
+    public int Count
+    {
+        get => _items.Count;
+    }
+
+    public bool IsReadOnly
+    {
+        get => false;
+    }
+
+    public T this[int index]
+    {
+        get => _items[index];
+        set => throw new NotSupportedException();
+    }
+
+    public int IndexOf(T item)
+    {
+        int index = _items.BinarySearch(item, _comparer);
+        if (index < 0)
+        {
+            index = -1;
+        }
+        return index;
+    }
+
+    int ItemIndex(T item)
+    {
+        return _items.BinarySearch(item, _comparer);
+    }
+
+    #endregion Properties
+
+    #region Add
+
+    public void Insert(int index, T item)
+    {
+        throw new NotSupportedException();
+    }
+
+    public void Add(T item)
+    {
+        int index = ItemIndex(item);
+
+        if (index < 0)
+        {
+            index = ~index;
+            _items.Insert(index, item);
+        }
+        else
+        {
+            throw new ArgumentException("Item already exists in the list.", nameof(item));
+        }
+    }
+
+    public int AddItem(T item)
+    {
+        int index = ItemIndex(item);
+        if (index < 0)
+        {
+            index = ~index;
+            _items.Insert(index, item);
+            return index;
+        }
+        return -1;
+    }
+
+    #endregion Add
+
+    #region Remove
+
+    public void RemoveAt(int index)
+    {
+        throw new NotSupportedException();
+    }
+
+    public bool Remove(T item)
+    {
+        throw new NotSupportedException();
+    }
+
+    public int RemoveItem(T item)
+    {
+        int index = IndexOf(item);
+        if (index >= 0)
+        {
+            _items.RemoveAt(index);
+            return index;
+        }
+        return -1;
+    }
+
+    public void Clear()
+    {
+        _items.Clear();
+    }
+
+    #endregion Remove
+
+    #region Misc
+
+    public bool Contains(T item)
+    {
+        return IndexOf(item) >= 0;
+    }
+
+    public void CopyTo(T[] array, int arrayIndex)
+    {
+        _items.CopyTo(array, arrayIndex);
+    }
+
+    #endregion Misc
+
+    #region IEnumerable
+
+    public IEnumerator<T> GetEnumerator()
+    {
+        return _items.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return ((IEnumerable)_items).GetEnumerator();
+    }
+
+    #endregion IEnumerable
+}
+

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ to the staff itself or notes, such as articulations, accidentals, tempo and dyna
 * Currently tracking [issue 3239](https://github.com/mono/SkiaSharp/issues/3239) in SkiaSharp
   * There is a workaround in the [GLyphView](https://github.com/DanTravison/GlyphViewer/issues/23)
   * There is another workaround in [SkLabel](https://github.com/DanTravison/GlyphViewer/issues/25)
-
+* Currently tracking [Discussion](https://github.com/dotnet/maui/discussions/29221)
+  * CollectionView does not support CollectionChanged events from custom collections for ItemsSource.
 
 # The Project Structure
 
@@ -151,7 +152,14 @@ This is used to select a font family group in the FontFamiliesView and a unicode
 * ObservableObject: An implementation of INotifyPropertyChanged with SetProperty overloads.
   * SetProperty takes an instance of a PropertyChangedEventArgs to allow derived class to statically define 
     PropertyChangedEventArgs instead of creating instances on each call. 
+* ObservableProperty - provides a base class for Settings properties.
+  * Provides PropertyChanged notification through the parent ObservableObject.
+  * Provides directly PropertyChanged notification for the encapsulated value.
+  * Allows SettingsPage to present Settings properties as a bindable collection. 
 * Command: An implementation of ICommand with IsEnabled for controlling CanExecute.
+* OrderedList: A simple ordered list of objects.
+  * This is a placeholder for use by FontFamilyGroup until CollectionView issue is resolved.
+  * The list is used to display the glyph and font metrics properties.
 
 ## Other
 * ExtendedUnicode.txt: A text file containing links to the Unicode ranges on www.unicode.org

--- a/Resources/Strings.Designer.cs
+++ b/Resources/Strings.Designer.cs
@@ -79,6 +79,24 @@ namespace GlyphViewer.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Bookmark the current font family.
+        /// </summary>
+        internal static string BookmarkCommandDescription {
+            get {
+                return ResourceManager.GetString("BookmarkCommandDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Bookmarks.
+        /// </summary>
+        internal static string BookmarkGroupName {
+            get {
+                return ResourceManager.GetString("BookmarkGroupName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Copied..
         /// </summary>
         internal static string CopiedText {

--- a/Resources/Strings.resx
+++ b/Resources/Strings.resx
@@ -165,4 +165,10 @@
   <data name="CopiedText" xml:space="preserve">
     <value>Copied.</value>
   </data>
+  <data name="BookmarkGroupName" xml:space="preserve">
+    <value>Bookmarks</value>
+  </data>
+  <data name="BookmarkCommandDescription" xml:space="preserve">
+    <value>Bookmark the current font family</value>
+  </data>
 </root>

--- a/Settings/FontSetting.cs
+++ b/Settings/FontSetting.cs
@@ -6,12 +6,12 @@ using System.ComponentModel;
 /// <summary>
 /// Provides a <see cref="DoubleSetting"/> for a font size.
 /// </summary>
-internal class FontSizeSetting : DoubleSetting
+public abstract class FontSetting : DoubleSetting
 {
     /// <summary>
     /// Initializes a new instance of this class.
     /// </summary>
-    /// <param name="propertyChanged">The <see cref="ObservableProperty.NotifyPropertyChangedDelegate"/>  delegate to invoke to raised the property chagned event.</param>
+    /// <param name="settings">The containing <see cref="SettingCollection"/>.</param>
     /// <param name="eventArgs">The optional <see cref="PropertyChangedEventArgs"/> to use when the value changes.</param>
     /// <param name="defaultValue">The default <see cref="Setting{T}.DefaultValue"/> of the setting.</param>
     /// <param name="displayName">The <see cref="Setting{T}.DisplayName"/> of the setting..</param>
@@ -22,23 +22,41 @@ internal class FontSizeSetting : DoubleSetting
     /// The default value is <see cref="EqualityComparer{T}.Default"/>.
     /// </para>
     /// </param>
-    public FontSizeSetting
+    protected FontSetting
     (
-        NotifyPropertyChangedDelegate propertyChanged,
+        SettingCollection settings,
         PropertyChangedEventArgs eventArgs,
         double defaultValue,
         string displayName,
         string description,
         IEqualityComparer<double> comparer = null
     )
-        : base(propertyChanged, eventArgs, defaultValue, displayName, description, comparer)
+        : base(settings, eventArgs, defaultValue, displayName, description, comparer)
     {
+        Increment = 1;
     }
 
     /// <summary>
     /// Gets the font family to use to display the sample text.
     /// </summary>
     public string FontFamily
+    {
+        get;
+        init;
+    }
+
+    /// <summary>
+    /// Gets the font size to use to display the sample text.
+    /// </summary>
+    public double FontSize
+    {
+        get => Value;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="FontAttributes"/> to use to display the sample text.
+    /// </summary>
+    public FontAttributes FontAttributes
     {
         get;
         init;

--- a/Settings/GlyphWidthSetting.cs
+++ b/Settings/GlyphWidthSetting.cs
@@ -1,27 +1,39 @@
 ﻿namespace GlyphViewer.Settings;
 
-using GlyphViewer.ObjectModel;
+using GlyphViewer.Resources;
+using GlyphViewer.Views;
 using System.ComponentModel;
 
-internal class GlyphWidthSetting : DoubleSetting
+/// <summary>
+/// Provides an <see cref="ISetting"/> for the <see cref="GlyphView"/> width.
+/// </summary>
+public class GlyphWidthSetting : DoubleSetting
 {
+    /// <summary>
+    /// Defines the minimum width of the <see cref="GlyphView"/>.
+    /// </summary>
+    public const double Minimum = 200;
+
+    /// <summary>
+    /// Defines the minimum width of the <see cref="GlyphView"/>.
+    /// </summary>
+    public const double Maximum = 500;
+
+    /// <summary>
+    /// Defines the default width of the <see cref="GlyphView"/>.
+    /// </summary>
+    public const double Default = 300;
+
     /// <summary>
     /// Initializes a new instance of this class.
     /// </summary>
-    /// <param name="propertyChanged">The <see cref="ObservableProperty.NotifyPropertyChangedDelegate"/>  delegate to invoke to raised the property chagned event.</param>
-    /// <param name="eventArgs">The optional <see cref="PropertyChangedEventArgs"/> to use when the value changes.</param>
-    /// <param name="defaultValue">The default <see cref="Setting{T}.DefaultValue"/> of the setting.</param>
-    /// <param name="displayName">The <see cref="Setting{T}.DisplayName"/> of the setting..</param>
-    /// <param name="description">The <see cref="Setting{T}.Description"/> of the setting.</param>
-    public GlyphWidthSetting
-    (
-        NotifyPropertyChangedDelegate propertyChanged,
-        PropertyChangedEventArgs eventArgs,
-        double defaultValue,
-        string displayName,
-        string description
-    )
-        : base(propertyChanged, eventArgs, defaultValue, displayName, description)
+    /// <param name="settings">The containing <see cref="SettingCollection"/>.</param>
+    /// <param name="eventArgs">The <see cref="PropertyChangedEventArgs"/> for the associated property.</param>
+    public GlyphWidthSetting(SettingCollection settings, PropertyChangedEventArgs eventArgs)
+        : base(settings, eventArgs, Default, Strings.GlyphWidthLabel, Strings.GlyphWidthDescription)
     {
+        MininumValue = Minimum;
+        MaximumValue = Maximum;
+        Increment = 10;
     }
 }

--- a/Settings/ISetting.cs
+++ b/Settings/ISetting.cs
@@ -3,8 +3,10 @@
 /// <summary>
 /// Provides an interface for a setting property.
 /// </summary>
-public interface ISetting
+public interface ISetting : ISettingSerializer
 {
+    #region Properties
+
     /// <summary>
     /// Gets the name of the setting.
     /// </summary>
@@ -12,6 +14,7 @@ public interface ISetting
     {
         get;
     }
+
     /// <summary>
     /// Gets the name to display in the UI.
     /// </summary>
@@ -19,6 +22,7 @@ public interface ISetting
     {
         get;
     }
+
     /// <summary>
     /// Gets the description of the setting.
     /// </summary>
@@ -26,6 +30,9 @@ public interface ISetting
     {
         get;
     }
+
+    #endregion Properties
+
     /// <summary>
     /// Resets the setting to its default state.
     /// </summary>

--- a/Settings/ISettingSerializer.cs
+++ b/Settings/ISettingSerializer.cs
@@ -1,0 +1,32 @@
+﻿namespace GlyphViewer.Settings;
+
+using System.Text.Json;
+
+
+/// <summary>
+/// Provides an interface for serializing an <see cref="ISetting"/> to/from JSON.
+/// </summary>
+public interface ISettingSerializer
+{
+    /// <summary>
+    /// Gets the value indicating if the setting has the default value.
+    /// </summary>
+    bool IsDefault
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Reads the value setting from the <paramref name="reader"/>
+    /// </summary>
+    /// <param name="reader">The <see cref="Utf8JsonReader"/> to read from.</param>
+    /// <param name="options">The <see cref="JsonSerializerOptions"/> to use to read the serialized value.</param>
+    void ReadValue(ref Utf8JsonReader reader, JsonSerializerOptions options);
+
+    /// <summary>
+    /// Writes the setting to the <paramref name="writer"/>.
+    /// </summary>
+    /// <param name="writer">The <see cref="Utf8JsonWriter"/> to write to.</param>
+    /// <param name="options">The <see cref="JsonSerializerOptions"/> to use to serialize the value.</param>
+    void WriteValue(Utf8JsonWriter writer, JsonSerializerOptions options);
+}

--- a/Settings/ItemFontSetting.cs
+++ b/Settings/ItemFontSetting.cs
@@ -1,0 +1,47 @@
+﻿namespace GlyphViewer.Settings;
+
+using GlyphViewer.Views;
+using GlyphViewer.Resources;
+using System.ComponentModel;
+
+/// <summary>
+/// Provides an <see cref="ISetting"/> for the <see cref="GlyphsView.ItemFontSize"/>.
+/// </summary>
+public sealed class ItemFontSetting : FontSetting
+{
+    /// <summary>
+    /// Defines the minimum <see cref="FontSetting.FontSize"/>.
+    /// </summary>
+    public const double Minimum = 12;
+
+    /// <summary>
+    /// Defines the maximum <see cref="FontSetting.FontSize"/>.
+    /// </summary>
+    public const double Maximum = 40;
+
+    /// <summary>
+    /// Defines the default <see cref="FontSetting.FontSize"/>.
+    /// </summary>
+    public const double Default = 32;
+
+    const string SampleItemFontText =
+        FluentUI.ArrowExportRTL + " "
+        + FluentUI.MusicNote1 + " "
+        + FluentUI.MusicNote2 + " "
+        + FluentUI.ArrowExportLTR;
+
+    /// <summary>
+    /// Initializes a new instance of this class.
+    /// </summary>
+    /// <param name="settings">The containing <see cref="SettingCollection"/>.</param>
+    /// <param name="eventArgs">The <see cref="PropertyChangedEventArgs"/> for the associated property.</param>
+    public ItemFontSetting(SettingCollection settings, PropertyChangedEventArgs eventArgs)
+        : base(settings, eventArgs, Default, Strings.ItemFontSizeLabel, Strings.ItemFontSizeDescription)
+    {
+        MininumValue = Minimum;
+        MaximumValue = Maximum;
+        Text = SampleItemFontText;
+        FontFamily = FluentUI.FamilyName;
+        FontAttributes = FontAttributes.None;
+    }
+}

--- a/Settings/ItemHeaderFontSetting.cs
+++ b/Settings/ItemHeaderFontSetting.cs
@@ -1,0 +1,51 @@
+﻿namespace GlyphViewer.Settings;
+
+using GlyphViewer.Views;
+using GlyphViewer.Resources;
+using System.ComponentModel;
+
+/// <summary>
+/// Provides an <see cref="ISetting"/> for the <see cref="GlyphsView.HeaderFontSize"/>.
+/// </summary>
+public sealed class ItemHeaderFontSetting : FontSetting
+{
+    /// <summary>
+    /// Defines the minimum <see cref="GlyphsView.HeaderFontSize"/>.
+    /// </summary>
+    public const double Minimum = 8;
+
+    /// <summary>
+    /// Defines the maximum <see cref="GlyphsView.HeaderFontSize"/>.
+    /// </summary>
+    public const double Maximum = 40;
+
+    /// <summary>
+    /// Define the default font size.
+    /// </summary>
+    public const double Default = 20;
+
+    /// <summary>
+    /// Define the default font family name.
+    /// </summary>
+    public const string DefaultFontFamily = App.DefaultFontFamily;
+
+    /// <summary>
+    /// Define the default <see cref="FontAttributes"/>.
+    /// </summary>
+    public const FontAttributes DefaultFontAttributes = FontAttributes.Bold | FontAttributes.Italic;
+
+    /// <summary>
+    /// Initializes a new instance of this class.
+    /// </summary>
+    /// <param name="settings">The containing <see cref="SettingCollection"/>.</param>
+    /// <param name="eventArgs">The <see cref="PropertyChangedEventArgs"/> for the associated property.</param>
+    public ItemHeaderFontSetting(SettingCollection settings, PropertyChangedEventArgs eventArgs)
+        : base(settings, eventArgs, Default, Strings.ItemHeaderFontSizeLabel, Strings.ItemHeaderFontSizeDescription)
+    {
+        MininumValue = Minimum;
+        MaximumValue = Maximum;
+        Text = GlyphViewer.Text.Unicode.Ranges.Latin1Supplement.Name;
+        FontFamily = Strings.DefaultFontFamily;
+        FontAttributes = DefaultFontAttributes;
+    }
+}

--- a/Settings/SettingCollection.cs
+++ b/Settings/SettingCollection.cs
@@ -1,0 +1,163 @@
+﻿namespace GlyphViewer.Settings;
+
+using GlyphViewer.ObjectModel;
+using System.Collections;
+using System.ComponentModel;
+
+/// <summary>
+/// Provides a serializable <see cref="ISetting"/> collection.
+/// </summary>
+public sealed class SettingCollection : ObservableObject, IReadOnlyCollection<ISetting>
+{
+    #region Fields
+
+    /// <summary>
+    /// Contains the <see cref="ISetting"/> properties that are editable by the user.
+    /// </summary>
+    readonly List<ISetting> _properties = [];
+    readonly Dictionary<string, ISetting> _all = new(StringComparer.CurrentCulture);
+    readonly NotifyPropertyChangedDelegate _propertyChanged;
+    bool _hasChanges;
+
+    #endregion Fields
+
+    /// <summary>
+    /// Initializes a new instance of this class.
+    /// </summary>
+    /// <param name="propertyChanged">
+    /// The <see cref="NotifyPropertyChangedDelegate"/> to invoke to notify the containing object a property has changed.
+    /// </param>
+    public SettingCollection(NotifyPropertyChangedDelegate propertyChanged)
+    {
+        _propertyChanged = propertyChanged;
+    }
+
+    #region Properties
+
+    /// <summary>
+    /// Gets the count of editable properties in the collection.
+    /// </summary>
+    public int Count
+    {
+        get => _properties.Count;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="IReadOnlyList{ISetting}"/> of settings that are user editable.
+    /// </summary>
+    public IReadOnlyList<ISetting> Properties
+    {
+        get => _properties;
+    }
+
+    #region HasChanges
+
+    /// <summary>
+    /// Gets the value indicating if the collection needs to be serialized.
+    /// </summary>
+    public bool HasChanges
+    {
+        get => _hasChanges;
+        set => SetProperty(ref _hasChanges, value, HasChangesChangedeEventArgs);
+    }
+
+    static readonly PropertyChangedEventArgs HasChangesChangedeEventArgs = new(nameof(HasChanges));
+
+    #endregion HasChanges
+
+    /// <summary>
+    /// Gets the <see cref="ISetting"/> with the specified <paramref name="name"/>.
+    /// </summary>
+    /// <param name="name">The name of the <see cref="ISetting"/> to get.</param>
+    /// <returns>
+    /// The <see cref="ISetting"/> with the specified <paramref name="name"/>;
+    /// otherwise, a null reference.
+    /// </returns>
+    public ISetting this[string name]
+    {
+        get
+        {
+            _all.TryGetValue(name, out ISetting setting);
+            return setting;
+        }
+    }
+
+    #endregion Properties
+
+    #region Public Methods
+
+    /// <summary>
+    /// Adds an <see cref="ISetting"/> to the editable properties.
+    /// </summary>
+    /// <typeparam name="S">The type of <see cref="ISetting"/>.</typeparam>
+    /// <param name="setting">The <see cref="ISetting"/> to add.</param>
+    /// <param name="canEdit">true if the user can edit the setting; otherwise, false.</param>
+    /// <returns>The added <typeparamref name="S"/> <see cref="ISetting"/>.</returns>
+    public S Add<S>(S setting, bool canEdit = true)
+        where S : ISetting
+    {
+        ArgumentNullException.ThrowIfNull(setting);
+        if (canEdit)
+        {
+            _properties.Add(setting);
+        }
+        _all.Add(setting.Name, setting);
+        return setting;
+    }
+
+    /// <summary>
+    /// Resets the properties to the default state.
+    /// </summary>
+    public void Reset()
+    {
+        foreach (ISetting setting in _all.Values)
+        {
+            if (!setting.IsDefault)
+            {
+                setting.Reset();
+            }
+        }
+    }
+
+    #endregion Public Methods
+
+    #region NotifyPropertyChanged
+
+    /// <summary>
+    /// Notifies the containing object that the property value changed.
+    /// </summary>
+    /// <param name="e">The <see cref="PropertyChangedEventArgs"/> identifying the property that changed.</param>
+    /// <remarks>
+    /// <see cref="UserSettings"/> should pass this method to the <see cref="ISetting"/> constructor.
+    /// </remarks>
+    public void NotifyPropertyChanged(PropertyChangedEventArgs e)
+    {
+        ArgumentNullException.ThrowIfNull(e);
+        HasChanges = true;
+        _propertyChanged?.Invoke(e);
+    }
+
+    #endregion NotifyPropertyChanged
+
+    #region IEnumerable
+
+    /// <summary>
+    /// Gets an  <see cref="IEnumerator{ISetting}"/> to enumerate all <see cref="ISetting"/> instances.
+    /// </summary>
+    /// <returns>An <see cref="IEnumerator{ISetting}"/>.</returns>
+    public IEnumerator<ISetting> GetEnumerator()
+    {
+        return _all.Values.GetEnumerator();
+    }
+
+    /// <summary>
+    /// Gets an  <see cref="IEnumerator"/> to enumerate all <see cref="ISetting"/> instances.
+    /// </summary>
+    /// <returns>An <see cref="IEnumerator"/>.</returns>
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return ((IEnumerable)_all.Values).GetEnumerator();
+    }
+
+    #endregion IEnumerable
+}

--- a/Settings/SettingDataTemplateSelector.cs
+++ b/Settings/SettingDataTemplateSelector.cs
@@ -7,7 +7,7 @@
 internal class SettingDataTemplateSelector : DataTemplateSelector
 {
     /// <summary>
-    /// Gets the <see cref="DataTemplate"/> for a <see cref="FontSizeSetting"/>.
+    /// Gets the <see cref="DataTemplate"/> for a <see cref="FontSetting"/>.
     /// </summary>
     public DataTemplate FontSize
     {
@@ -45,7 +45,7 @@ internal class SettingDataTemplateSelector : DataTemplateSelector
     /// </exception>
     protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
     {
-        if (item is FontSizeSetting)
+        if (item is FontSetting)
         {
             return FontSize;
         }

--- a/Settings/TitleFontSetting.cs
+++ b/Settings/TitleFontSetting.cs
@@ -1,0 +1,48 @@
+﻿namespace GlyphViewer.Settings;
+
+using GlyphViewer.Resources;
+using GlyphViewer.Views;
+using System.ComponentModel;
+
+public class TitleFontSetting : FontSetting
+{
+    /// <summary>
+    /// Defines the minimum width of the <see cref="GlyphView"/>.
+    /// </summary>
+    public const double Minimum = 20;
+
+    /// <summary>
+    /// Defines the minimum width of the <see cref="GlyphView"/>.
+    /// </summary>
+    public const double Maximum = 50;
+
+    /// <summary>
+    /// Define the default font size of the main page header text.
+    /// </summary>
+    public const double Default = 32;
+
+    /// <summary>
+    /// Define the default font family name.
+    /// </summary>
+    public const string DefaultFontFamily = App.DefaultFontFamily;
+
+    /// <summary>
+    /// Define the default <see cref="FontAttributes"/>.
+    /// </summary>
+    public const FontAttributes DefaultFontAttributes = FontAttributes.Bold | FontAttributes.Italic;
+
+    /// <summary>
+    /// Initializes a new instance of this class.
+    /// </summary>
+    /// <param name="settings">The containing <see cref="SettingCollection"/>.</param>
+    /// <param name="eventArgs">The <see cref="PropertyChangedEventArgs"/> for the associated property.</param>
+    public TitleFontSetting(SettingCollection settings, PropertyChangedEventArgs eventArgs)
+        : base(settings, eventArgs, Default, Strings.TitleFontSizeLabel, Strings.TitleFontSizeDescription)
+    {
+        MininumValue = Minimum;
+        MaximumValue = Maximum;
+        Text = DefaultFontFamily;
+        FontFamily = DefaultFontFamily;
+        FontAttributes = DefaultFontAttributes;
+    }
+}

--- a/Settings/UserSettings.cs
+++ b/Settings/UserSettings.cs
@@ -2,13 +2,14 @@
 
 using GlyphViewer.ObjectModel;
 using GlyphViewer.Resources;
+using GlyphViewer.Text;
 using GlyphViewer.ViewModels;
 using GlyphViewer.Views;
 using System.Collections;
 using System.ComponentModel;
 
 /// <summary>
-/// Provides a view model for managing user settings.
+/// Provides a model for managing user settings.
 /// </summary>
 public sealed class UserSettings : ObservableObject
 {
@@ -133,6 +134,12 @@ public sealed class UserSettings : ObservableObject
     /// Defines the default border color for the <see cref="GlyphsView.SelectedItem"/>
     /// </summary>
     public static readonly Color DefaultSelectedItemColor = Colors.Plum;
+
+    /// <summary>
+    /// Defines the font families that are marked with a bookmark.
+    /// </summary>
+    // TODO: Needs serialization.
+    readonly FontFamilyBookmarks _bookmarks = [];
 
     #endregion Fields
 
@@ -273,6 +280,16 @@ public sealed class UserSettings : ObservableObject
         get;
     }
 
+    /// <summary>
+    /// Gets the <see cref="FontFamilyBookmarks"/>.
+    /// </summary>
+    public FontFamilyBookmarks Bookmarks
+    {
+        // TODO: Convert UserSettings to a JSON storage.
+        // Preference is not a good place to store bookmarks since it's string type is limited in size.
+        get => _bookmarks;
+    }
+
     #endregion Properties
 
     /// <summary>
@@ -308,5 +325,4 @@ public sealed class UserSettings : ObservableObject
     public static PropertyChangedEventArgs TitleFontSizeChangedEventArgs = new(nameof(TitleFontSize));
 
     #endregion PropertyChangedEventArgs
-
 }

--- a/Text/FontFamilyBookmarks.cs
+++ b/Text/FontFamilyBookmarks.cs
@@ -1,0 +1,177 @@
+﻿namespace GlyphViewer.Text;
+
+using GlyphViewer.ObjectModel;
+using GlyphViewer.Resources;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+/// <summary>
+/// Provides a group of bookmarked font families.
+/// </summary>
+public sealed class FontFamilyBookmarks : ReadOnlyCollection<string>, IFontFamilyGroup, INotifyCollectionChanged, INotifyPropertyChanged
+{
+    // ISSUE: CollectionView will not subscribe to CollectionChanged events
+    // for a class that implements IReadOnlyList<T> and INotifyCollectionChanged.
+    // However, it will subscribe to a class derived from ReadOnlyCollection<T>.
+    // See https://github.com/dotnet/maui/discussions/29221
+    // Once this is resolved, revert ReadOnlyCollection to IReadOnlyCollection<T>
+
+    #region Fields
+
+    readonly OrderedList<string> _families;
+    readonly IComparer<string> _comparer = StringComparer.CurrentCulture;
+
+    #endregion Fields
+
+    /// <summary>
+    /// Initializes a new instance of this class.
+    /// </summary>
+    public FontFamilyBookmarks()
+        : base(new OrderedList<string>(StringComparer.CurrentCulture))
+    {
+        _families = base.Items as OrderedList<string>;
+        Name = Strings.BookmarkGroupName;
+    }
+
+    #region Properties
+
+    /// <summary>
+    /// Gets the name of the group.
+    /// </summary>
+    public string Name
+    {
+        get;
+    }
+
+    #endregion Properties
+
+    #region Methods
+
+    /// <summary>
+    /// Adds a new font family to the collection.
+    /// </summary>
+    /// <param name="familyName">The name of the font family to add.</param>
+    /// <returns>true if the <paramref name="familyName"/> was added; otherwise, 
+    /// false if the <paramref name="familyName"/> already exists in the collection.
+    /// </returns>
+    public bool Add(string familyName)
+    {
+        int index = _families.AddItem(familyName);
+        if (index >= 0)
+        {
+            OnItemAdded(index, familyName);
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Replaces the collection contents with the specified <paramref name="families"/>.
+    /// </summary>
+    /// <param name="families">The <see cref="IEnumerable{T}"/> for the items to use to populate the collection.</param>
+    public void Update(IEnumerable<string> families)
+    {
+        _families.Clear();
+        foreach (string familyName in families)
+        {
+            _families.AddItem(familyName);
+        }
+        NotifyCollectionChangedEventHandler handler = CollectionChanged;
+        if (handler is not null && _families.Count > 0)
+        {
+            handler?.Invoke(this, new(NotifyCollectionChangedAction.Add, _families, 0));
+        }
+    }
+
+    /// <summary>
+    /// Removes a font family from the collection.
+    /// </summary>
+    /// <param name="familyName">The name of the font family to remove.</param>
+    /// <returns>true if the <paramref name="familyName"/> was removed; otherwise,
+    /// false if the <paramref name="familyName"/> does not exist in the collection.
+    /// </returns>
+    public bool Remove(string familyName)
+    {
+        int index = _families.RemoveItem(familyName);
+        if (index >= 0)
+        {
+            OnItemRemoved(index, familyName);
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Removes all items from the collection.
+    /// </summary>
+    public void Clear()
+    {
+        OnClear();
+    }
+
+    #endregion Methods
+
+    #region INotifyPropertyChanged
+
+    static readonly PropertyChangedEventArgs CountChangedEventArgs = new(nameof(Count));
+
+    /// <summary>
+    /// Occurs when a property changes.
+    /// </summary>
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    #endregion INotifyPropertyChanged
+
+    #region INotifyCollectionChanged
+
+    /// <summary>
+    /// Occurs when the collection changes.
+    /// </summary>
+    public event NotifyCollectionChangedEventHandler CollectionChanged;
+
+    static readonly NotifyCollectionChangedEventArgs CollectionResetEventArgs = new(NotifyCollectionChangedAction.Reset);
+
+    #endregion INotifyCollectionChanged
+
+    #region Collection Updates
+
+    void OnItemAdded(int index, string item)
+    {
+        NotifyCollectionChangedEventHandler handler = CollectionChanged;
+        if (handler is not null)
+        {
+            handler?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, index));
+        }
+        PropertyChanged?.Invoke(this, CountChangedEventArgs);
+    }
+
+    void OnItemRemoved(int index, string item)
+    {
+        NotifyCollectionChangedEventHandler handler = CollectionChanged;
+        if (handler is not null)
+        {
+            handler?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index));
+        }
+        PropertyChanged?.Invoke(this, CountChangedEventArgs);
+    }
+
+    void OnClear()
+    {
+        NotifyCollectionChangedEventHandler handler = CollectionChanged;
+        List<string> removed = null;
+        if (handler is not null)
+        {
+            removed = new(_families);
+        }
+        _families.Clear();
+        if (handler is not null)
+        {
+            handler.Invoke(this, new(NotifyCollectionChangedAction.Remove, removed, 0));
+            handler.Invoke(this, CollectionResetEventArgs);
+        }
+        PropertyChanged?.Invoke(this, CountChangedEventArgs);
+    }
+
+    #endregion Collection Updates
+}

--- a/Text/FontFamilyGroup.cs
+++ b/Text/FontFamilyGroup.cs
@@ -5,9 +5,9 @@ using System.Collections;
 /// <summary>
 /// Provides a group of font families.
 /// </summary>
-public sealed class FontFamilyGroup : IReadOnlyCollection<string>
+public sealed class FontFamilyGroup : IReadOnlyCollection<string>, IFontFamilyGroup
 {
-    readonly List<string> _families = new();
+    readonly List<string> _families = [];
 
     /// <summary>
     /// Initializes a new instance of this class
@@ -75,15 +75,6 @@ public sealed class FontFamilyGroup : IReadOnlyCollection<string>
             throw new ArgumentNullException(nameof(family));
         }
         _families.Add(family);
-    }
-
-    /// <summary>
-    /// Sort the font families in the group.
-    /// </summary>
-    /// <param name="comparer">The <see cref="IComparer{T}"/> to use to sort the values.</param>
-    public void Sort(IComparer<string> comparer)
-    {
-        _families.Sort(comparer);
     }
 
     #endregion Methods

--- a/Text/FontFamilyGroup.cs
+++ b/Text/FontFamilyGroup.cs
@@ -26,6 +26,7 @@ public sealed class FontFamilyGroup : IReadOnlyCollection<string>, IFontFamilyGr
     public string Name
     {
         get;
+        init;
     }
 
     /// <summary>
@@ -68,13 +69,14 @@ public sealed class FontFamilyGroup : IReadOnlyCollection<string>, IFontFamilyGr
     /// The specified <paramref name="family"/> is a
     /// null reference or empty string.
     /// </exception>
-    public void Add(string family)
+    public bool Add(string family)
     {
         if (string.IsNullOrEmpty(family))
         {
             throw new ArgumentNullException(nameof(family));
         }
         _families.Add(family);
+        return true;
     }
 
     #endregion Methods

--- a/Text/FontFamilyGroupCollection.cs
+++ b/Text/FontFamilyGroupCollection.cs
@@ -5,7 +5,7 @@ using System.Collections;
 /// <summary>
 /// Provides a collection of <see cref="FontFamilyGroup"/> items.
 /// </summary>
-public sealed class FontFamilyGroupCollection : IReadOnlyCollection<FontFamilyGroup>
+public sealed class FontFamilyGroupCollection : IReadOnlyList<FontFamilyGroup>
 {
     #region Fields
 
@@ -19,8 +19,14 @@ public sealed class FontFamilyGroupCollection : IReadOnlyCollection<FontFamilyGr
     /// </summary>
     /// <param name="groupTable">The <see cref="Dictionary{String, FontFamilyGroup}"/>.</param>
     /// <param name="groups">The <see cref="List{FontFamilyGroup}"/> of groups.</param>
-    FontFamilyGroupCollection(Dictionary<string, FontFamilyGroup> groupTable, List<FontFamilyGroup> groups)
+    FontFamilyGroupCollection
+    (
+        Dictionary<string, FontFamilyGroup> groupTable,
+        List<FontFamilyGroup> groups,
+        FontFamilyBookmarks bookmarks
+    )
     {
+        Bookmarks = new List<IFontFamilyGroup>([bookmarks]);
         _groups = groups;
         _groupTable = groupTable;
     }
@@ -52,6 +58,27 @@ public sealed class FontFamilyGroupCollection : IReadOnlyCollection<FontFamilyGr
     public int Count
     {
         get => _groups.Count;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="FontFamilyGroup"/> at the specified <paramref name="index"/>.
+    /// </summary>
+    /// <param name="index">The zero-based index of the <see cref="FontFamilyGroup"/> to get.</param>
+    /// <returns>The <see cref="FontFamilyGroup"/> at the specified <paramref name="index"/>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is less than zero or greater than or equal to <see cref="Count"/>.
+    /// </exception>
+    public FontFamilyGroup this[int index]
+    {
+        get => _groups[index];
+    }
+
+    /// <summary>
+    /// Gets the bookmarks for the font families.
+    /// </summary>
+    public IReadOnlyList<IFontFamilyGroup> Bookmarks
+    {
+        get;
     }
 
     #endregion Properties
@@ -88,17 +115,24 @@ public sealed class FontFamilyGroupCollection : IReadOnlyCollection<FontFamilyGr
     /// Creates a new instance of this class.
     /// </summary>
     /// <returns>A new instance of a <see cref="FontFamilyGroupCollection"/>.</returns>
-    public static FontFamilyGroupCollection CreateInstance()
+    public static FontFamilyGroupCollection CreateInstance(FontFamilyBookmarks bookmarks)
     {
         Dictionary<string, FontFamilyGroup> groupTable = new(StringComparer.OrdinalIgnoreCase);
         List<FontFamilyGroup> groups = [];
 
         List<string> families = Fonts.GetFontFamilies();
-        // Ensure group names and font familyl names are sorted.
+        // the bookmarked font families that are actually available.
+        List<string> availableBookmarks = [];
+
+        // Ensure group names and font family names are sorted.
         families.Sort(StringComparer.CurrentCultureIgnoreCase);
 
         foreach (string fontFamily in families)
         {
+            if (bookmarks.Contains(fontFamily))
+            {
+                availableBookmarks.Add(fontFamily);
+            }
             string groupName = fontFamily[0].ToString();
             if (!groupTable.TryGetValue(groupName, out FontFamilyGroup group))
             {
@@ -108,7 +142,18 @@ public sealed class FontFamilyGroupCollection : IReadOnlyCollection<FontFamilyGr
             }
             group.Add(fontFamily);
         }
-        return new(groupTable, groups);
+
+        if (availableBookmarks.Count > 0)
+        {
+            // NOTE: Update the UserSettings.Bookmarks collection to ensure it doesn't
+            // include fonts that are no longer available.
+            bookmarks.Update(availableBookmarks);
+        }
+        else
+        {
+            bookmarks.Clear();
+        }
+        return new(groupTable, groups, bookmarks);
     }
 
     #endregion CreateInstance

--- a/Text/FontFamilyGroupCollection.cs
+++ b/Text/FontFamilyGroupCollection.cs
@@ -1,5 +1,6 @@
 ﻿namespace GlyphViewer.Text;
 
+using GlyphViewer.Settings;
 using System.Collections;
 
 /// <summary>
@@ -23,7 +24,7 @@ public sealed class FontFamilyGroupCollection : IReadOnlyList<FontFamilyGroup>
     (
         Dictionary<string, FontFamilyGroup> groupTable,
         List<FontFamilyGroup> groups,
-        FontFamilyBookmarks bookmarks
+        Bookmarks bookmarks
     )
     {
         Bookmarks = new List<IFontFamilyGroup>([bookmarks]);
@@ -115,7 +116,7 @@ public sealed class FontFamilyGroupCollection : IReadOnlyList<FontFamilyGroup>
     /// Creates a new instance of this class.
     /// </summary>
     /// <returns>A new instance of a <see cref="FontFamilyGroupCollection"/>.</returns>
-    public static FontFamilyGroupCollection CreateInstance(FontFamilyBookmarks bookmarks)
+    internal static FontFamilyGroupCollection CreateInstance(Bookmarks bookmarks)
     {
         Dictionary<string, FontFamilyGroup> groupTable = new(StringComparer.OrdinalIgnoreCase);
         List<FontFamilyGroup> groups = [];

--- a/Text/IFontFamilyGroup.cs
+++ b/Text/IFontFamilyGroup.cs
@@ -1,0 +1,9 @@
+﻿namespace GlyphViewer.Text;
+
+/// <summary>
+/// Provides a collection of font family names.
+/// </summary>
+public interface IFontFamilyGroup : IReadOnlyList<string>
+{
+    string Name { get; }
+}

--- a/Text/IFontFamilyGroup.cs
+++ b/Text/IFontFamilyGroup.cs
@@ -5,5 +5,16 @@
 /// </summary>
 public interface IFontFamilyGroup : IReadOnlyList<string>
 {
-    string Name { get; }
+    /// <summary>
+    /// Gets the name of the group.
+    /// </summary>
+    string Name { get; init; }
+
+    /// <summary>
+    /// adds a font family name to the group.
+    /// </summary>
+    /// <param name="familyName">The name of the font family.</param>
+    /// <returns>true if the <paramref name="familyName"/> was added; otherwise, 
+    /// false if the <paramref name="familyName"/> is already present.</returns>
+    bool Add(string familyName);
 }

--- a/ViewModels/BookmarkCommand.cs
+++ b/ViewModels/BookmarkCommand.cs
@@ -1,0 +1,121 @@
+﻿namespace GlyphViewer.ViewModels;
+
+using GlyphViewer.ObjectModel;
+using GlyphViewer.Text;
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+/// <summary>
+/// Provides a <see cref="Command"/> for setting or clearing a font family bookmark.
+/// </summary>
+internal sealed class BookmarkCommand : Command
+{
+    #region Fields
+
+    readonly FontFamilyBookmarks _bookmarks;
+    readonly MetricsModel _metrics;
+    bool _isBookmarked;
+
+    #endregion Fields
+
+    /// <summary>
+    /// Initializes a new instance of this command.
+    /// </summary>
+    /// <param name="bookmarks">The <see cref="FontFamilyBookmarks"/> to update.</param>
+    public BookmarkCommand(FontFamilyBookmarks bookmarks, MetricsModel metrics)
+        : base(NopAction)
+    {
+        _bookmarks = bookmarks;
+        _bookmarks.CollectionChanged += OnBookmarksChanged;
+        _metrics = metrics;
+        _metrics.PropertyChanged += OnMetricsPropertyChanged;
+        IsEnabled = false;
+    }
+
+    #region Properties
+
+    /// <summary>
+    /// Gets or sets the current font family name.
+    /// </summary>
+    public string FamilyName
+    {
+        get => _metrics.FontFamily;
+    }
+
+    /// <summary>
+    /// Gets the value indicating if the <see cref="FamilyName"/> is bookmarked.
+    /// </summary>
+    public bool IsBookmarked
+    {
+        get => _isBookmarked;
+        private set => SetProperty(ref _isBookmarked, value, IsBookmarkedChangedEventArgs);
+    }
+
+    #endregion Properties
+
+    #region Event Handlers
+
+    private void OnBookmarkChanged()
+    {
+        IsBookmarked = !string.IsNullOrEmpty(FamilyName) && _bookmarks.Contains(FamilyName);
+    }
+
+    private void OnFamilyNameChanged()
+    {
+        string familyName = _metrics.FontFamily;
+        IsEnabled = !string.IsNullOrEmpty(familyName);
+        OnBookmarkChanged();
+    }
+
+    private void OnMetricsPropertyChanged(object sender, PropertyChangedEventArgs e)
+    {
+        if (ReferenceEquals(e, MetricsModel.FontFamilyChangedEventArgs))
+        {
+            OnFamilyNameChanged();
+        }
+    }
+
+    private void OnBookmarksChanged(object sender, NotifyCollectionChangedEventArgs e)
+    {
+        OnBookmarkChanged();
+    }
+
+    #endregion Event Handlers
+
+    #region Execute
+
+    /// <summary>
+    /// Adds or removes the <see cref="FamilyName"/> from the bookmarks.
+    /// </summary>
+    /// <param name="_">Not used.</param>
+    public override sealed void Execute(object _)
+    {
+        if (!string.IsNullOrEmpty(FamilyName))
+        {
+            if (IsBookmarked)
+            {
+                _bookmarks.Remove(FamilyName);
+            }
+            else
+            {
+                _bookmarks.Add(FamilyName);
+            }
+            IsBookmarked = _bookmarks.Contains(FamilyName);
+        }
+    }
+
+    #endregion Execute
+
+    #region PropertyChangedEventArgs
+
+    /// <summary>
+    /// Provides <see cref="PropertyChangedEventArgs"/> when <see cref="FamilyName"/> changes.
+    /// </summary>
+    static readonly PropertyChangedEventArgs FamilyNameChangedEventArgs = new(nameof(FamilyName));
+    /// <summary>
+    /// Provides <see cref="PropertyChangedEventArgs"/> when <see cref="Glyph"/> changes.
+    /// </summary>
+    static readonly PropertyChangedEventArgs IsBookmarkedChangedEventArgs = new(nameof(IsBookmarked));
+
+    #endregion PropertyChangedEventArgs
+}

--- a/ViewModels/BookmarkCommand.cs
+++ b/ViewModels/BookmarkCommand.cs
@@ -1,6 +1,7 @@
 ﻿namespace GlyphViewer.ViewModels;
 
 using GlyphViewer.ObjectModel;
+using GlyphViewer.Settings;
 using GlyphViewer.Text;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -12,7 +13,7 @@ internal sealed class BookmarkCommand : Command
 {
     #region Fields
 
-    readonly FontFamilyBookmarks _bookmarks;
+    readonly Bookmarks _bookmarks;
     readonly MetricsModel _metrics;
     bool _isBookmarked;
 
@@ -21,8 +22,8 @@ internal sealed class BookmarkCommand : Command
     /// <summary>
     /// Initializes a new instance of this command.
     /// </summary>
-    /// <param name="bookmarks">The <see cref="FontFamilyBookmarks"/> to update.</param>
-    public BookmarkCommand(FontFamilyBookmarks bookmarks, MetricsModel metrics)
+    /// <param name="bookmarks">The <see cref="Bookmarks"/> to update.</param>
+    public BookmarkCommand(Bookmarks bookmarks, MetricsModel metrics)
         : base(NopAction)
     {
         _bookmarks = bookmarks;

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -20,7 +20,7 @@ internal sealed class MainViewModel : ObservableObject
     int _row;
     int _rows;
     ICommand _pickUnicodeRangeCommand;
-    MetricsModel _metrics;
+    readonly MetricsModel _metrics;
 
     #endregion Fields
 
@@ -36,11 +36,10 @@ internal sealed class MainViewModel : ObservableObject
         Settings.PropertyChanged += OnSettingsPropertyChanged;
         _metrics = new MetricsModel(Settings.ItemFontSize);
         _metrics.PropertyChanged += OnMetricsPropertyChanged;
+        BookmarkCommand = new(Settings.Bookmarks, _metrics);
     }
 
     #region Properties
-
-    #region Settings
 
     /// <summary>
     /// Gets the <see cref="Settings.UserSettings"/>.
@@ -50,7 +49,13 @@ internal sealed class MainViewModel : ObservableObject
         get;
     }
 
-    #endregion Settings
+    /// <summary>
+    /// Gets the command for updating the currenty selected font family in bookmarks.
+    /// </summary>
+    public BookmarkCommand BookmarkCommand
+    {
+        get;
+    }
 
     /// <summary>
     /// Gets the <see cref="MetricsModel"/> for the selected <see cref="Glyph"/> and font family.
@@ -217,7 +222,7 @@ internal sealed class MainViewModel : ObservableObject
 
     public void LoadFonts(IDispatcher dispatcher)
     {
-        FontFamilyGroupCollection families = FontFamilyGroupCollection.CreateInstance();
+        FontFamilyGroupCollection families = FontFamilyGroupCollection.CreateInstance(Settings.Bookmarks);
         _ = dispatcher.DispatchAsync(() =>
         {
             FontFamilyGroups = families;

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -32,9 +32,9 @@ internal sealed class MainViewModel : ObservableObject
     public MainViewModel(IDispatcher dispatcher)
     {
         _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
-        Settings = new UserSettings();
+        Settings = UserSettings.Load();
         Settings.PropertyChanged += OnSettingsPropertyChanged;
-        _metrics = new MetricsModel(Settings.ItemFontSize);
+        _metrics = new MetricsModel(Settings.ItemFont.FontSize);
         _metrics.PropertyChanged += OnMetricsPropertyChanged;
         BookmarkCommand = new(Settings.Bookmarks, _metrics);
     }
@@ -257,9 +257,16 @@ internal sealed class MainViewModel : ObservableObject
 
     private void OnSettingsPropertyChanged(object sender, PropertyChangedEventArgs e)
     {
-        if (ReferenceEquals(e, UserSettings.ItemFontSizeChangedEventArgs))
+        if (ReferenceEquals(e, ObservableProperty.ValueChangedEventArgs))
         {
-            _metrics.FontSize = Settings.ItemFontSize;
+            if (ReferenceEquals(sender, Settings.ItemFont))
+            {
+                _metrics.FontSize = Settings.ItemFont.FontSize;
+            }
+            else if (ReferenceEquals(sender, Settings.GlyphWidth))
+            {
+                _metrics.GlyphWidth = Settings.GlyphWidth.Value;
+            }
         }
     }
 

--- a/ViewModels/MetricsModel.cs
+++ b/ViewModels/MetricsModel.cs
@@ -24,6 +24,7 @@ internal sealed class MetricsModel : ObservableObject, IDisposable
     Glyph _glyph = Glyph.Empty;
     GlyphMetricProperties _glyphProperties;
     readonly Command _clipboardCommand;
+    double _glyphWidth;
 
     #endregion Fields
 
@@ -33,12 +34,12 @@ internal sealed class MetricsModel : ObservableObject, IDisposable
     /// Initializes a new instance of this class.
     /// </summary>
     /// <param name="fontSize">The initial font size in points.</param>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="fontSize"/> is less than <see cref="UserSettings.MinimumItemFontSize"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="fontSize"/> is less than <see cref="ItemFontSetting.Minimum"/>.</exception>
     public MetricsModel(double fontSize)
     {
-        if (fontSize < UserSettings.MinimumItemFontSize)
+        if (fontSize < ItemFontSetting.Minimum)
         {
-            throw new ArgumentOutOfRangeException(nameof(fontSize), fontSize, $"Font size must be greater than {UserSettings.MinimumItemFontSize}.");
+            throw new ArgumentOutOfRangeException(nameof(fontSize), fontSize, $"Font size must be greater than {ItemFontSetting.Minimum}.");
         }
         _fontFamily = string.Empty;
         _glyph = Glyph.Empty;
@@ -176,6 +177,15 @@ internal sealed class MetricsModel : ObservableObject, IDisposable
     public GlyphMetricProperties GlyphProperties
     {
         get => _glyphProperties;
+    }
+
+    /// <summary>
+    /// Gets the width, in pixels, to display the glyph.
+    /// </summary>
+    public double GlyphWidth
+    {
+        get => _glyphWidth;
+        set => SetProperty(ref _glyphWidth, value, GlyphWidthChangedEventArgs);
     }
 
     #endregion Glyph Properties
@@ -446,6 +456,12 @@ internal sealed class MetricsModel : ObservableObject, IDisposable
     /// The <see cref="PropertyChangedEventArgs"/> for the <see cref="FontProperties"/> property.
     /// </summary>
     public static readonly PropertyChangedEventArgs FontPropertiesChangedEventArgs = new(nameof(FontProperties));
+
+    /// <summary>
+    /// The <see cref="PropertyChangedEventArgs"/> for the <see cref="GlyphWidth"/> property.
+    /// </summary>
+    public static readonly PropertyChangedEventArgs GlyphWidthChangedEventArgs = new(nameof(GlyphWidth));
+
 
     /// <summary>
     /// The <see cref="PropertyChangedEventArgs"/> for the <see cref="Glyph"/> property.

--- a/Views/FontFamiliesView.xaml
+++ b/Views/FontFamiliesView.xaml
@@ -27,62 +27,73 @@
             </Setter>
         </Style>
 
-        <DataTemplate x:DataType="text:FontFamilyGroup" x:Key="JumpListItemTemplate">
+        <DataTemplate x:DataType="text:IFontFamilyGroup" x:Key="JumpListItemTemplate">
             <Label Text="{Binding Name}"
                    Style="{StaticResource JumpListItemStyle}"/>
         </DataTemplate>
+
+        <DataTemplate x:DataType="text:IFontFamilyGroup" x:Key="GroupHeaderTemplate">
+            <HorizontalStackLayout Style="{StaticResource GroupHeaderStyle}">
+                <Label Text="{Binding Name}"
+                           FontSize="18"
+                           FontAttributes="Bold"
+                           Margin="0"
+                           TextColor="{AppThemeBinding Light={StaticResource PrimaryDarkText}, Dark=WhiteSmoke}"
+                           />
+                <HorizontalStackLayout.GestureRecognizers>
+                    <!-- TODO: convert this to a command -->
+                    <TapGestureRecognizer Tapped="OnPickGroup"/>
+                </HorizontalStackLayout.GestureRecognizers>
+            </HorizontalStackLayout>
+        </DataTemplate>
+
+        <DataTemplate x:DataType="x:String" x:Key="GroupItemTemplate">
+            <Label Text="{Binding}"
+                           Style="{StaticResource NameStyle}"
+                           />
+        </DataTemplate>
+
+        <Style TargetType="CollectionView" x:Key="FontFamilyGroupStyle">
+            <Setter Property="IsGrouped" Value="True"/>
+            <Setter Property="SelectionMode" Value="Single"/>
+            <Setter Property="SelectedItem" Value="{Binding Metrics.FontFamily, Mode=TwoWay}"/>
+            <Setter Property="GroupHeaderTemplate" Value="{StaticResource GroupHeaderTemplate}"/>
+            <Setter Property="ItemTemplate" Value="{StaticResource GroupItemTemplate}"/>
+        </Style>
 
     </ContentView.Resources>
 
     <!-- NOTE: Placing ContentView directly in a '*' row can cause
          the content to overflow the row. Use 'Auto,*' as a workaround.
     -->
-    <Grid RowDefinitions="Auto, *">
+    <Grid RowDefinitions="Auto, Auto, Auto, *">
 
+        <CollectionView Grid.Row="0"
+                        Style="{StaticResource FontFamilyGroupStyle}"
+                        ItemsSource="{Binding FontFamilyGroups.Bookmarks, Mode=OneWay}"
+                        Margin="0"
+                        />
+
+        <BoxView Grid.Row="1" 
+                 Style="{StaticResource HorizontalSeparatorStyle}"/>
+        
         <!-- NOTE: Placing Families and GroupPicker in the same row/column.
              Using JumpList.ZIndex to show/hide the picker.
         -->
         <controls:JumpList x:Name="GroupPicker" 
-                           Grid.Row="0"
+                           Grid.Row="2"
                            Grid.RowSpan="2"
-                           ItemsSource="{Binding FontFamilyGroups}"
+                           ItemsSource="{Binding FontFamilyGroups, Mode=OneWay}"
                            SelectedItem="{Binding SelectedFamilyGroup, Mode=OneWayToSource}"
                            ItemTemplate="{StaticResource JumpListItemTemplate}"
                            />
 
         <CollectionView x:Name="Families"
-                        Grid.Row="0"
+                        Grid.Row="2"
                         Grid.RowSpan="2"
-                        ItemsSource="{Binding FontFamilyGroups}"
-                        SelectionMode="Single"
-                        SelectedItem="{Binding Metrics.FontFamily, Mode=TwoWay}"
-                        IsGrouped="true"
-                        >
-            <CollectionView.GroupHeaderTemplate>
-                <DataTemplate x:DataType="text:FontFamilyGroup">
-                    <HorizontalStackLayout Style="{StaticResource GroupHeaderStyle}">
-                        <Label Text="{Binding Name}"
-                           FontSize="18"
-                           FontAttributes="Bold"
-                           Margin="0"
-                           TextColor="{AppThemeBinding Light={StaticResource PrimaryDarkText}, Dark=WhiteSmoke}"
-                           />
-                        <HorizontalStackLayout.GestureRecognizers>
-                            <!-- TODO: convert this to a command -->
-                            <TapGestureRecognizer Tapped="OnPickGroup"/>
-                        </HorizontalStackLayout.GestureRecognizers>
-                    </HorizontalStackLayout>
-                </DataTemplate>
-            </CollectionView.GroupHeaderTemplate>
-            <CollectionView.ItemTemplate>
-                <DataTemplate x:DataType="x:String">
-                    <Label Text="{Binding}"
-                           Style="{StaticResource NameStyle}"
-                           />
-                </DataTemplate>
-            </CollectionView.ItemTemplate>
-        </CollectionView>
-
+                        Style="{StaticResource FontFamilyGroupStyle}"
+                        ItemsSource="{Binding FontFamilyGroups, Mode=OneWay}"
+                        />
     </Grid>
 
 </ContentView>

--- a/Views/FontFamiliesView.xaml
+++ b/Views/FontFamiliesView.xaml
@@ -66,7 +66,7 @@
     <!-- NOTE: Placing ContentView directly in a '*' row can cause
          the content to overflow the row. Use 'Auto,*' as a workaround.
     -->
-    <Grid RowDefinitions="Auto, Auto, Auto, *">
+    <Grid RowDefinitions="Auto, Auto, *">
 
         <CollectionView Grid.Row="0"
                         Style="{StaticResource FontFamilyGroupStyle}"
@@ -74,14 +74,11 @@
                         Margin="0"
                         />
 
-        <BoxView Grid.Row="1" 
-                 Style="{StaticResource HorizontalSeparatorStyle}"/>
-        
         <!-- NOTE: Placing Families and GroupPicker in the same row/column.
              Using JumpList.ZIndex to show/hide the picker.
         -->
         <controls:JumpList x:Name="GroupPicker" 
-                           Grid.Row="2"
+                           Grid.Row="21"
                            Grid.RowSpan="2"
                            ItemsSource="{Binding FontFamilyGroups, Mode=OneWay}"
                            SelectedItem="{Binding SelectedFamilyGroup, Mode=OneWayToSource}"
@@ -89,7 +86,7 @@
                            />
 
         <CollectionView x:Name="Families"
-                        Grid.Row="2"
+                        Grid.Row="1"
                         Grid.RowSpan="2"
                         Style="{StaticResource FontFamilyGroupStyle}"
                         ItemsSource="{Binding FontFamilyGroups, Mode=OneWay}"

--- a/Views/FontFamiliesView.xaml.cs
+++ b/Views/FontFamiliesView.xaml.cs
@@ -1,5 +1,4 @@
 using GlyphViewer.ViewModels;
-using System.Runtime.CompilerServices;
 
 namespace GlyphViewer.Views;
 
@@ -12,7 +11,7 @@ public partial class FontFamiliesView : ContentView
         InitializeComponent();
     }
 
-    protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
+    protected override void OnPropertyChanged(string propertyName)
     {
         if (BindingContextProperty.PropertyName == propertyName)
         {
@@ -31,13 +30,17 @@ public partial class FontFamiliesView : ContentView
 
     private void OnModelPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        if (_model is not null && ReferenceEquals(e, MainViewModel.SelectedFamilyGroupChangedEventArgs))
+        if
+        (
+            _model is not null
+            &&
+            ReferenceEquals(e, MainViewModel.SelectedFamilyGroupChangedEventArgs)
+            &&
+            _model.SelectedFamilyGroup is not null
+        )
         {
-            if (_model.SelectedFamilyGroup is not null)
-            {
-                string fontFamily = _model.SelectedFamilyGroup[0];
-                Families.ScrollTo(fontFamily, _model.SelectedFamilyGroup, ScrollToPosition.Start, false);
-            }
+            string fontFamily = _model.SelectedFamilyGroup[0];
+            Families.ScrollTo(fontFamily, _model.SelectedFamilyGroup, ScrollToPosition.Start, false);
         }
     }
 

--- a/Views/GlyphsView.cs
+++ b/Views/GlyphsView.cs
@@ -29,16 +29,6 @@ public sealed class GlyphsView : SKCanvasView
     public const double DefaultSpacing = 5.0;
 
     /// <summary>
-    /// Defines the default <see cref="HeaderFontSize"/>.
-    /// </summary>
-    public const string DefaultHeaderFontFamily = App.DefaultFontFamily;
-
-    /// <summary>
-    /// Defines the default <see cref="HeaderFontAttributes"/>.
-    /// </summary>
-    public const FontAttributes DefaultHeaderFontAttributes = FontAttributes.Bold | FontAttributes.Italic;
-
-    /// <summary>
     /// Defines the default <see cref="HeaderColor"/>.
     /// </summary>
     public static readonly Color DefaultHeaderColor = Colors.Black;
@@ -298,17 +288,15 @@ public sealed class GlyphsView : SKCanvasView
         nameof(ItemFontSize),
         typeof(double),
         typeof(GlyphsView),
-        UserSettings.DefaultItemFontSize,
+        ItemFontSetting.Default,
         BindingMode.OneWay,
         coerceValue: (bindable, value) =>
         {
-            return UserSettings.Constrain
-            (
-                value,
-                UserSettings.MinimumItemFontSize,
-                UserSettings.MaximumItemFontSize,
-                UserSettings.DefaultItemFontSize
-            );
+            if (value is double fontSize)
+            {
+                return Math.Clamp(fontSize, ItemFontSetting.Minimum, ItemFontSetting.Maximum);
+            }
+            return ItemFontSetting.Default;
         },
         propertyChanged: (bindable, oldValue, newValue) =>
         {
@@ -420,7 +408,7 @@ public sealed class GlyphsView : SKCanvasView
         nameof(HeaderFontFamily),
         typeof(string),
         typeof(GlyphsView),
-        DefaultHeaderFontFamily,
+        ItemHeaderFontSetting.DefaultFontFamily,
         BindingMode.OneWay,
         coerceValue: (bindable, value) =>
         {
@@ -432,7 +420,7 @@ public sealed class GlyphsView : SKCanvasView
                     return value;
                 }
             }
-            return DefaultHeaderFontFamily;
+            return ItemHeaderFontSetting.DefaultFontFamily;
         },
         propertyChanged: (bindable, oldValue, newValue) =>
         {
@@ -464,17 +452,15 @@ public sealed class GlyphsView : SKCanvasView
         nameof(HeaderFontSize),
         typeof(double),
         typeof(GlyphsView),
-        UserSettings.DefaultItemHeaderFontSize,
+        ItemHeaderFontSetting.Default,
         BindingMode.OneWay,
         coerceValue: (bindable, value) =>
         {
-            return UserSettings.Constrain
-            (
-                value,
-                UserSettings.MinimumItemHeaderFontSize,
-                UserSettings.MaximumItemHeaderFontSize,
-                UserSettings.DefaultItemFontSize
-            );
+            if (value is double fontSize)
+            {
+                return Math.Clamp(fontSize, ItemHeaderFontSetting.Minimum, ItemHeaderFontSetting.Maximum);
+            }
+            return ItemHeaderFontSetting.Default;
         },
         propertyChanged: (bindable, oldValue, newValue) =>
         {
@@ -514,9 +500,8 @@ public sealed class GlyphsView : SKCanvasView
         nameof(HeaderFontAttributes),
         typeof(FontAttributes),
         typeof(GlyphsView),
-        DefaultHeaderFontAttributes,
+        ItemHeaderFontSetting.DefaultFontAttributes,
         BindingMode.OneWay
-
     );
 
     #endregion HeaderFontAttributes

--- a/Views/HeaderView.xaml
+++ b/Views/HeaderView.xaml
@@ -3,14 +3,16 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:viewmodel="clr-namespace:GlyphViewer.ViewModels"
              xmlns:controls="clr-namespace:GlyphViewer.Controls"
+             xmlns:settngs="clr-namespace:GlyphViewer.Settings"
              xmlns:res="clr-namespace:GlyphViewer.Resources"
              x:Class="GlyphViewer.Views.HeaderView"
              x:DataType="viewmodel:MainViewModel">
 
     <ContentView.Resources>
         <Style TargetType="Label" x:Key="TitleLabelStyle">
-            <Setter Property="FontSize" Value="{Binding Settings.TitleFontSize}"/>
-            <Setter Property="FontAttributes" Value="Bold"/>
+            <!-- TODO: Use Binding.FontSize when Setting is updated -->
+            <Setter Property="FontSize" Value="{Binding Settings.TitleFont.Value}"/>
+            <Setter Property="FontAttributes" Value="{Binding Settings.TitleFont.FontAttributes}"/>
             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource PrimaryDarkText}, Dark=WhiteSmoke}"/>
         </Style>
         

--- a/Views/HeaderView.xaml
+++ b/Views/HeaderView.xaml
@@ -13,6 +13,32 @@
             <Setter Property="FontAttributes" Value="Bold"/>
             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource PrimaryDarkText}, Dark=WhiteSmoke}"/>
         </Style>
+        
+        <Style TargetType="Button" x:Key="BookmarkButtonStyle"
+               BasedOn="{StaticResource GlyphButtonStyle}"
+               x:DataType="viewmodel:BookmarkCommand"
+               >
+            <Setter Property="Text" Value="{x:Static res:FluentUI.Bookmark}"/>
+            <Setter Property="Command" Value="{Binding}"/>
+            <Setter Property="ToolTipProperties.Text" Value="{x:Static res:Strings.BookmarkCommandDescription}"/>
+            <Setter Property="IsVisible" Value="{Binding IsEnabled}"/>
+            <Style.Triggers>
+                <DataTrigger TargetType="Button"
+                             Binding="{Binding IsBookmarked}"
+                             Value="True">
+                    <Setter Property="Text"
+                            Value="{x:Static res:FluentUI.BookmarkFilled}"/>
+                </DataTrigger>
+
+                <DataTrigger TargetType="Button"
+                             Binding="{Binding IsBookmarked}"
+                             Value="False">
+                    <Setter Property="Text"
+                            Value="{x:Static res:FluentUI.Bookmark}"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+        
     </ContentView.Resources>
 
     <Grid ColumnDefinitions="1*,2*,1*"
@@ -23,13 +49,18 @@
                Grid.Row="0"
                Grid.Column="0"
                />
-        
-        <Label Text="{Binding Metrics.FontFamily}"
-               Style="{StaticResource TitleLabelStyle}"
-               HorizontalOptions="Center"
-               Grid.Row="0"
-               Grid.Column="1"
-               />
+
+        <HorizontalStackLayout HorizontalOptions="Center"
+                               Spacing="5"
+                               Grid.Row="0"
+                               Grid.Column="1">
+            <Label Text="{Binding Metrics.FontFamily}"
+                   Style="{StaticResource TitleLabelStyle}"
+                   />
+            <Button BindingContext="{Binding BookmarkCommand}"
+                    Style="{StaticResource BookmarkButtonStyle}"
+                    />
+        </HorizontalStackLayout>
 
         <Grid ColumnDefinitions="Auto, Auto"
               ColumnSpacing="5"

--- a/Views/MainPage.xaml
+++ b/Views/MainPage.xaml
@@ -41,13 +41,16 @@
                                ItemTemplate="{StaticResource JumpListItemTemplate}"
                                OpenCommand="{Binding PickUnicodeRangeCommand}"/>
 
+            <!-- TODO: Use Binding.FontSize when Setting is updated -->
             <views:GlyphsView Grid.Column="1"
                               Items="{Binding Glyphs}"
                               ItemColor="{AppThemeBinding Light={StaticResource PrimaryDarkText}, Dark={StaticResource White}}"
                               HeaderColor="{AppThemeBinding Light={StaticResource PrimaryDarkText}, Dark={StaticResource White}}"
                               BackgroundColor="Transparent"
-                              ItemFontSize="{Binding Metrics.FontSize}"
-                              HeaderFontSize="{Binding Settings.ItemHeaderFontSize}"
+                              ItemFontSize="{Binding Settings.ItemFont.Value}"
+                              HeaderFontSize="{Binding Settings.ItemHeaderFont.Value}"
+                              HeaderFontAttributes="{Binding Settings.ItemHeaderFont.FontAttributes}"
+                              HeaderFontFamily="{Binding Settings.ItemHeaderFont.FontFamily}"
                               SelectedItem="{Binding Metrics.Glyph, Mode=TwoWay}"
                               HeaderClickedCommand="{Binding PickUnicodeRangeCommand}"
                               UnicodeRanges="{Binding UnicodeRanges}"
@@ -74,12 +77,10 @@
                                  BackgroundColor="{AppThemeBinding Light={StaticResource PrimaryDarkText}, Dark=WhiteSmoke}"
                                  LineColor="{AppThemeBinding Light=Tomato, Dark=Red}"
                                  BaselineColor="{AppThemeBinding Light=LightGreen, Dark=Green}"
-                                 MinimumWidthRequest="{Binding Settings.GlyphWidth}"
+                                 WidthRequest="{Binding Metrics.GlyphWidth}"
                                  />
 
-                <!-- NOTE: WidthRequest ensures the view width doesn't resize when properties change -->
                 <views:MetricsView Grid.Row="1"
-                                   WidthRequest="{Binding Settings.GlyphWidth}"
                                    BindingContext="{Binding Metrics}"
                                    />
 

--- a/Views/MainPage.xaml.cs
+++ b/Views/MainPage.xaml.cs
@@ -15,7 +15,7 @@ public partial class MainPage : ContentPage
     protected override void OnNavigatedTo(NavigatedToEventArgs args)
     {
         base.OnNavigatedTo(args);
-        if (_model.Glyphs is null)
+        if (_model.FontFamilyGroups is null)
         {
             Task.Run(() => { _model.LoadFonts(Dispatcher); });
         }

--- a/Views/MetricsView.xaml
+++ b/Views/MetricsView.xaml
@@ -5,7 +5,9 @@
              xmlns:text="clr-namespace:GlyphViewer.Text"
              xmlns:controls="clr-namespace:GlyphViewer.Controls"
              x:Class="GlyphViewer.Views.MetricsView"
-             x:DataType="viewmodel:MetricsModel">
+             x:DataType="viewmodel:MetricsModel"
+             WidthRequest="{Binding GlyphWidth}"
+            >
 
     <ScrollView>
         <VerticalStackLayout Spacing="5">

--- a/Views/SettingsPage.xaml
+++ b/Views/SettingsPage.xaml
@@ -27,9 +27,11 @@
             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource PrimaryDarkText}, Dark=WhiteSmoke}"/>
         </Style>
 
-        <Style TargetType="controls:SkLabel" x:Key="FontSizeStyle" x:DataType="settings:FontSizeSetting">
+        <Style TargetType="controls:SkLabel" x:Key="FontSizeStyle" x:DataType="settings:FontSetting">
             <Setter Property="FontFamily" Value="{Binding FontFamily}"/>
-            <Setter Property="FontSize" Value="{Binding Value, Mode=OneWay}"/>
+            <!-- TODO: Use Binding.FontSize when Setting is updated -->
+            <Setter Property="FontSize" Value="{Binding Value}"/>
+            <Setter Property="FontAttributes" Value="{Binding FontAttributes}"/>
             <Setter Property="Text" Value="{Binding Text}"/>
             <Setter Property="ToolTipProperties.Text" Value="{Binding Description}"/>
             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource PrimaryDarkText}, Dark=WhiteSmoke}"/>
@@ -89,7 +91,7 @@
             </settings:SettingDataTemplateSelector.GlyphWidth>
 
             <settings:SettingDataTemplateSelector.FontSize>
-                <DataTemplate x:DataType="settings:FontSizeSetting">
+                <DataTemplate x:DataType="settings:FontSetting">
                     <Grid ColumnDefinitions="*, 400, Auto"
                           RowDefinitions="Auto, Auto"
                           RowSpacing="5"
@@ -131,9 +133,10 @@
                 Grid.Column="0"
                 />
 
+        <!-- TODO: Use Binding.FontSize when Setting is updated -->
         <Label Text="{x:Static res:Strings.SettingsTitle}"
                HorizontalOptions="Center"
-               FontSize="{Binding TitleFontSize, Mode=OneWay}"
+               FontSize="{Binding TitleFont.Value, Mode=OneWay}"
                Grid.Row="0"
                Grid.Column="0"
                Grid.ColumnSpan="3"


### PR DESCRIPTION
Fix #27: Support marking a font with a bookmark.
- Add a dynamically populated Bookmarks CollectionView to the FontFamilies view

Change Maui Preferences usage to JSON settings file to address unbounded Bookmark serialization size.
- Add explicit classes for each user configurable setting.
- Add a bookmarks setting class for implicit user configuration.
- Update XAML bindings to use the new setting classes.
