### PR TITLE
Fix #54: The sliders are not visible when using the light theme.

### DIFF
--- a/Controls/Slider/Slider.cs
+++ b/Controls/Slider/Slider.cs
@@ -25,12 +25,12 @@ public sealed class Slider : SKCanvasView
     /// <summary>
     /// Defines the default <see cref="TrackColor"/> <see cref="Color"/>.
     /// </summary>
-    public static readonly Color DefaultTrackColor = Colors.White;
+    public static readonly Color DefaultTrackColor = Colors.WhiteSmoke;
 
     /// <summary>
     /// Defines the default <see cref="ThumbColor"/> <see cref="Color"/>.
     /// </summary>
-    public static readonly Color DefaultThumbColor = Colors.White;
+    public static readonly Color DefaultThumbColor = Colors.WhiteSmoke;
 
     /// <summary>
     /// Defines the default <see cref="DisabledColor"/> <see cref="Color"/>. 
@@ -527,7 +527,7 @@ public sealed class Slider : SKCanvasView
         nameof(TrackColor),
         typeof(Color),
         typeof(Slider),
-        Colors.White,
+        DefaultTrackColor,
         propertyChanged: (bindableObject, oldValue, newValue) =>
         {
             if (bindableObject is Slider slider)
@@ -558,7 +558,7 @@ public sealed class Slider : SKCanvasView
         nameof(ThumbColor),
         typeof(Color),
         typeof(Slider),
-        Colors.White,
+        DefaultThumbColor,
         propertyChanged: (bindableObject, oldValue, newValue) =>
         {
             if (bindableObject is Slider slider)

--- a/Resources/Styles/Styles.xaml
+++ b/Resources/Styles/Styles.xaml
@@ -23,6 +23,13 @@
                 Value="0" />
     </Style>
 
+    <Style TargetType="controls:Slider"
+           ApplyToDerivedTypes="True">
+        <Setter Property="ThumbColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark=WhiteSmoke}"/>
+        <Setter Property="TrackColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark=WhiteSmoke}"/>
+        <Setter Property="DisabledColor" Value="{StaticResource Gray200}"/>
+    </Style>
+
     <Style TargetType="Label" x:Key="NameStyle">
         <Setter Property="FontSize" Value="{StaticResource DefaultFontSize}"/>
         <Setter Property="Margin" Value="5, 0, 5, 5"/>


### PR DESCRIPTION
Styles.xaml:
- Add Style entry for controls:Slider

Slider:
- Update DefaultTrackColor and DefaultThumbColor constants
- Update TrackColor and ThumbColor to use constants as default values.