### PR TITLE
Canvas view MeasureOverride workaround.

### DIFF
--- a/Controls/CanvasViewHandler.cs
+++ b/Controls/CanvasViewHandler.cs
@@ -1,0 +1,39 @@
+﻿namespace GlyphViewer.Controls;
+
+using SkiaSharp.Views.Maui.Controls;
+using SkiaSharp.Views.Maui.Handlers;
+
+/// <summary>
+/// Provides a custom <see cref="SKCanvasViewHandler"/> for handing issue 18700 https://github.com/mono/SkiaSharp/issues/3239
+/// </summary>
+internal class CanvasViewHandler : SKCanvasViewHandler
+{
+    public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
+    {
+        Size size = Size.Zero;
+        if (this.VirtualView is SKCanvasView view)
+        {
+            size = view.DesiredSize;
+        }
+        if (size == Size.Zero)
+        {
+            size = base.GetDesiredSize(widthConstraint, heightConstraint);
+        }
+        return size;
+    }
+}
+
+/// <summary>
+/// Provides a <see cref="MauiAppBuilder"/> for configuring <see cref="CanvasViewHandler"/>.
+/// </summary>
+public static class CanvasViewExtensions
+{
+    public static MauiAppBuilder UseCanvasView(this MauiAppBuilder builder)
+    {
+        builder.ConfigureMauiHandlers(handlers =>
+        {
+            handlers.AddHandler<SKCanvasView, CanvasViewHandler>();
+        });
+        return builder;
+    }
+}

--- a/Controls/SkLabel.cs
+++ b/Controls/SkLabel.cs
@@ -62,14 +62,6 @@ internal class SkLabel : SKCanvasView
 
     void InvalidateText()
     {
-        // Workaround for SkLabel does not resize after the first call to InvalidateMeasure
-        // https://github.com/DanTravison/GlyphViewer/issues/25
-        // See https://github.com/mono/SkiaSharp/issues/3239
-        // NOTE: Unless HeightRequest is explicitly cleared, MeasureOverride does not get called
-        // after the first successful attempt to resize the control.
-        // Additionally, MeasureOverride must explicitly set HeightRequest.
-        HeightRequest = -1;
-
         _needsMetrics = true;
         InvalidateMeasure();
         InvalidateSurface();
@@ -343,13 +335,6 @@ internal class SkLabel : SKCanvasView
 
         float width = (float)Padding.HorizontalThickness + _metrics.TextWidth;
         float height = (float)Padding.VerticalThickness + _metrics.Size.Height;
-
-        // Workaround for SkLabel does not resize after the first call to InvalidateMeasure
-        // https://github.com/DanTravison/GlyphViewer/issues/25
-        // See https://github.com/mono/SkiaSharp/issues/3239
-        // NOTE: Must explicitly set HeightRequest here as well as in InvalidateText
-        HeightRequest = height;
-
         return new Size(width, height);
     }
 

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 #endif
 using SkiaSharp.Views.Maui.Controls.Hosting;
 using GlyphViewer.Diagnostics;
+using GlyphViewer.Controls;
 
 public static class MauiProgram
 {
@@ -22,6 +23,9 @@ public static class MauiProgram
             .UseMauiApp<App>()
             .UseSkiaSharp()
             .UseMauiCommunityToolkit()
+            // Workaround for Issue 18700 https://github.com/mono/SkiaSharp/issues/3239
+            // [BUG] InvalidateMeasure doesn't call MeasureOverride after the first call.
+            .UseCanvasView()
             .ConfigureFonts(fonts =>
             {
                 FontLoader.Load(fonts, FontLoader.Defaults);

--- a/Views/GlyphView.cs
+++ b/Views/GlyphView.cs
@@ -300,10 +300,6 @@ public class GlyphView : SKCanvasView
         // to the desired height when the glyph is empty or the glyph height < desired height
         if (heightRequest != HeightRequest)
         {
-            // Address GlyphView does not size correctly when glyph's height exceeds the height of the glyph view.
-            // https://github.com/DanTravison/GlyphViewer/issues/23
-            // See https://github.com/mono/SkiaSharp/issues/3239
-            HeightRequest = heightRequest;
             InvalidateMeasure();
         }
         InvalidateSurface();


### PR DESCRIPTION
Work around for SkiaSharp issue [3239](https://github.com/mono/SkiaSharp/issues/3239) [BUG] InvalidateMeasure doesn't call MeasureOverride after the first call.

CanvasViewHandler:
- A derived SKCanvasViewHandler that overrides GetDesiredSize and returns view.DesiredSize, if defined.

CanvasViewExtensions:
- Provides a UseCanvasView MauiAppBuilder extension to enable CanvasViewHandler

SKLabel:
- Remove custom workaround for 18700.

GlyphView:
- Remove custom workaround for 18700

MauiProgram:
- Call UseCanvasView