### PR TITLE
Fix #65: Add Previous and Next buttons to sliders

### DIFF
--- a/Controls/Layouts/Layout.cs
+++ b/Controls/Layouts/Layout.cs
@@ -1,0 +1,243 @@
+﻿namespace GlyphViewer.Controls.Layouts;
+
+/// <summary>
+/// Provides an abstract base <see cref="Layout"/> class.
+/// </summary>
+/// <typeparam name="I">The type of <see cref="LayoutInfo"/> to use to layout child items.</typeparam>
+public abstract class Layout<I> : Layout
+    where I : LayoutInfo
+{
+    #region Fields
+
+    readonly Dictionary<IView, I> _layoutInfo = new(ReferenceEqualityComparer.Instance);
+    Size _measuredSize = Size.Zero;
+
+    #endregion Fields
+
+    /// <summary>
+    /// Initializes a new instance of this class.
+    /// </summary>
+    protected Layout()
+    { }
+
+    #region Properties
+
+    /// <summary>
+    /// Gets the <typeparamref name="I"/> <see cref="Info"/> for the specified <paramref name="view"/> view.
+    /// </summary>
+    /// <param name="view">The <see cref="IView"/> of information to retrieve.</param>
+    /// <returns>The <typeparamref name="I"/> <see cref="Info"/>, if found; otherwise, a null reference.</returns>
+    public I this[IView view]
+    {
+        get
+        {
+            _layoutInfo.TryGetValue(view, out I info);
+            return info;
+        }
+    }
+
+    /// <summary>
+    /// Enumerates the <typeparamref name="I"/> <see cref="LayoutInfo"/> for each view.
+    /// </summary>
+    /// <returns>An <see cref="IEnumerable{T}"/>.</returns>
+    protected IEnumerable<I> Info
+    {
+        get => _layoutInfo.Values;
+    }
+
+    #endregion Properties
+
+    #region Add
+
+    void AddView(IView view)
+    {
+        I info = CreateItemInfo(view);
+        if (info is not null)
+        {
+            _layoutInfo.Add(view, info);
+            OnItemAdded(info);
+        }
+    }
+
+    /// <summary>
+    /// Creates an instance of <typeparamref name="I"/> <see cref="LayoutInfo"/>.
+    /// </summary>
+    /// <param name="view">The <see cref="IView"/> to arrange.</param>
+    /// <returns>A new instance of a <typeparamref name="I"/> <see cref="LayoutInfo"/>.</returns>
+    protected abstract I CreateItemInfo(IView view);
+
+    /// <summary>
+    /// Overridden in the derived class when a <see cref="IView"/> is added.
+    /// </summary>
+    /// <param name="info">The <typeparamref name="I"/> for the added view.</param>
+    protected virtual void OnItemAdded(I info)
+    {
+    }
+
+    #endregion Add
+
+    #region Remove
+
+    void RemoveView(IView view)
+    {
+        if (_layoutInfo.TryGetValue(view, out I info))
+        {
+            _layoutInfo.Remove(view);
+            OnItemRemoved(info);
+            info.Removed();
+        }
+    }
+
+    /// <summary>
+    /// Overridden in the derived class when a <see cref="IView"/> is removed.
+    /// </summary>
+    /// <param name="info">The <typeparamref name="I"/> for the removed view.</param>
+    protected virtual void OnItemRemoved(I info)
+    {
+    }
+
+    #endregion Remove
+
+    #region Find
+
+    /// <summary>
+    /// Find the <typeparamref name="I"/> <see cref="LayoutInfo"/> for the item 
+    /// at the specified <paramref name="point"/>.
+    /// </summary>
+    /// <param name="point">The <see cref="Point"/> to query.</param>
+    /// <returns>
+    /// The <typeparamref name="I"/> <see cref="LayoutInfo"/> for the item 
+    /// at the specified <paramref name="point"/>; otherwise, a null reference.
+    /// </returns>
+    public I Find(Point point)
+    {
+        foreach (I info in _layoutInfo.Values)
+        {
+            if (info.Bounds.Contains(point))
+            {
+                return info;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Find the child <see cref="View"/> at the specified <paramref name="point"/>.
+    /// </summary>
+    /// <param name="point">The <see cref="Point"/> to query.</param>
+    /// <returns>
+    /// The <see cref="View"/> for the child at the specified <paramref name="point"/>;
+    /// otherwise, a null reference.
+    /// </returns>
+    public View FindChild(Point point)
+    {
+        if (Find(point) is I info)
+        {
+            return info.View as View;
+        }
+        return null;
+    }
+
+    #endregion Find
+
+    #region Overrides
+
+    /// <summary>
+    /// Updates the size of an View.
+    /// </summary>
+    /// <param name="widthConstraint">The width that a parent element can allocate a child element.</param>
+    /// <param name="heightConstraint">The height that a parent element can allocate a child element.</param>
+    /// <returns>The desired Size for this element.</returns>
+    protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
+    {
+        bool needsMeasure = _measuredSize.Width != widthConstraint || _measuredSize.Height != heightConstraint;
+        if (needsMeasure)
+        {
+            foreach (LayoutInfo info in _layoutInfo.Values)
+            {
+                info.View.InvalidateMeasure();
+            }
+        }
+        else
+        {
+            foreach (LayoutInfo info in _layoutInfo.Values)
+            {
+                if (info.NeedsMeasure)
+                {
+                    needsMeasure = true;
+                    break;
+                }
+            }
+        }
+        if (needsMeasure)
+        {
+            _measuredSize = base.MeasureOverride(widthConstraint, heightConstraint);
+        }
+        return _measuredSize;
+    }
+
+    /// <summary>
+    /// Adds an <see cref="IView"/> to the <see cref="Layout.Children"/> collection.
+    /// </summary>
+    /// <param name="index">The zero-based index to add.</param>
+    /// <param name="view">The <see cref="IView"/> to add.</param>
+    protected override sealed void OnAdd(int index, IView view)
+    {
+        base.OnAdd(index, view);
+        AddView(view);
+        InvalidateMeasure();
+    }
+
+    /// <summary>
+    /// Inserts an <see cref="IView"/> into the <see cref="Layout.Children"/> collection.
+    /// </summary>
+    /// <param name="index">The zero-based index to insert at.</param>
+    /// <param name="view">The <see cref="IView"/> to add.</param>
+    protected override sealed void OnInsert(int index, IView view)
+    {
+        base.OnInsert(index, view);
+        AddView(view);
+        InvalidateMeasure();
+    }
+
+    /// <summary>
+    /// Removes an <see cref="IView"/> from the <see cref="Layout.Children"/> collection.
+    /// </summary>
+    /// <param name="index">The zero-based index of the <see cref="IView"/> to remove.</param>
+    /// <param name="view">The <see cref="IView"/> to remove.</param>
+    protected override sealed void OnRemove(int index, IView view)
+    {
+        base.OnRemove(index, view);
+        RemoveView(view);
+        InvalidateMeasure();
+    }
+
+    /// <summary>
+    /// Replaces an <see cref="IView"/> in the <see cref="Layout.Children"/> collection.
+    /// </summary>
+    /// <param name="index">The zero-based index of the <see cref="IView"/> to update.</param>
+    /// <param name="view">The <see cref="IView"/> to set.</param>
+    /// <param name="oldView">The <see cref="IView"/> to replace.</param>
+    protected override sealed void OnUpdate(int index, IView view, IView oldView)
+    {
+        base.OnUpdate(index, view, oldView);
+        RemoveView(oldView);
+        AddView(view);
+        InvalidateMeasure();
+    }
+
+    /// <summary>
+    /// Removes all items from the <see cref="Layout.Children"/> collection.
+    /// </summary>
+    protected override sealed void OnClear()
+    {
+        base.OnClear();
+        foreach (I info in _layoutInfo.Values)
+        {
+            RemoveView(info.View);
+        }
+        InvalidateMeasure();
+    }
+
+    #endregion Overrides
+}

--- a/Controls/Layouts/LayoutInfo.cs
+++ b/Controls/Layouts/LayoutInfo.cs
@@ -1,0 +1,253 @@
+﻿namespace GlyphViewer.Controls;
+
+using Microsoft.Maui.Layouts;
+using System.Runtime.CompilerServices;
+
+/// <summary>
+/// Provides layout info for a <see cref="Layout"/> and <see cref="LayoutManager"/>class.
+/// </summary>
+public class LayoutInfo
+{
+    #region Fields
+
+    IView _view;
+    Rect _bounds;
+    bool _needsMeasure = true;
+
+    #endregion Fields
+
+    /// <summary>
+    /// Initializes a new instance of this class.
+    /// </summary>
+    /// <param name="view">The <see cref="IView"/> for the item.</param>
+    public LayoutInfo(IView view)
+    {
+        View = view;
+    }
+
+    /// <summary>
+    /// Releases the associated <see cref="View"/> and any event handlers.
+    /// </summary>
+    internal void Removed()
+    {
+        if (View is VisualElement visual)
+        {
+            visual.MeasureInvalidated -= OnMeasureInvalidated;
+            visual.BindingContext = null;
+        }
+        _view = null;
+    }
+
+    #region Properties
+
+    /// <summary>
+    /// Gets the <see cref="IView"/> for this item.
+    /// </summary>
+    public IView View
+    {
+        get => _view;
+        protected set
+        {
+            if (_view is not null)
+            {
+                if (_view is VisualElement visual)
+                {
+                    visual.MeasureInvalidated -= OnMeasureInvalidated;
+                }
+            }
+            _view = value;
+            if (_view is not null)
+            {
+                if (_view is VisualElement visual)
+                {
+                    visual.MeasureInvalidated += OnMeasureInvalidated;
+                }
+                _needsMeasure = true;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the desired <see cref="Rect"/> for the item.
+    /// </summary>
+    public Rect Bounds
+    {
+        get => _bounds;
+        set
+        {
+            if (_bounds != value)
+            {
+                _bounds = value;
+                NeedsArrange = true;
+            }
+            NeedsMeasure = false;
+        }
+    }
+
+    /// <summary>
+    /// Gets the size of the item.
+    /// </summary>
+    public Size Size
+    {
+        get => _bounds.Size;
+        set
+        {
+            if (_bounds.Size != value)
+            {
+                _bounds.Width = value.Width;
+                _bounds.Height = value.Height;
+                _needsMeasure = true;
+            }
+            else
+            {
+                _needsMeasure = false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the width.
+    /// </summary>
+    public double Width
+    {
+        get => _bounds.Width;
+    }
+
+    /// <summary>
+    /// Gets the height.
+    /// </summary>
+    public double Height
+    {
+        get => _bounds.Height;
+    }
+
+    /// <summary>
+    /// Gets or sets the value indicating if the item needs to be measured.
+    /// </summary>
+    public virtual bool NeedsMeasure
+    {
+        get
+        {
+            if (!_needsMeasure)
+            {
+                _needsMeasure =
+                (
+                    double.IsNaN(View.Width)
+                    ||
+                    double.IsNaN(View.Height)
+                    ||
+                    double.IsFinite(Bounds.Width) || !double.IsFinite(Bounds.Height)
+                 );
+            }
+            return _needsMeasure;
+        }
+        set => _needsMeasure = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the value indicating if the item needs to be arranged.
+    /// </summary>
+    public bool NeedsArrange
+    {
+        get;
+        set;
+    }
+
+    #endregion Properties
+
+    #region Measure
+
+    private void OnMeasureInvalidated(object sender, EventArgs e)
+    {
+        NeedsMeasure = true;
+    }
+
+    /// <summary>
+    /// Measures the <see cref="View"/>.
+    /// </summary>
+    /// <param name="widthConstraint">The width constraint.</param>
+    /// <param name="heightConstraint">The height constraint.</param>
+    /// <returns>The measured size of the <see cref="View"/>.</returns>
+    public virtual Size Measure(double widthConstraint, double heightConstraint)
+    {
+        Size size = View.Measure(widthConstraint, heightConstraint);
+        Size = size;
+        _needsMeasure = false;
+        return Bounds.Size;
+    }
+
+    #endregion Measure
+
+    #region Arrange
+
+    /// <summary>
+    /// Arranges the <see cref="View"/> is the specified <see cref="Rect"/>.
+    /// </summary>
+    /// <param name="bounds">The <see cref="Rect"/> to use to arrange the <see cref="View"/>.</param>
+    public void Arrange(Rect bounds)
+    {
+        Bounds = bounds;
+        Arrange();
+    }
+
+    /// <summary>
+    /// Arranges the <see cref="View"/> to the <see cref="Bounds"/>.
+    /// </summary>
+    public virtual void Arrange()
+    {
+        Rect bounds = Bounds;
+
+        if (bounds.X != View.Frame.X
+            || bounds.Y != View.Frame.Y
+            || bounds.Width != View.Width
+            || bounds.Height != View.Height
+        )
+        {
+            View.Arrange(Bounds);
+        }
+        NeedsArrange = false;
+    }
+
+    #endregion Arrange
+
+    /// <summary>
+    /// Constrains a dimension based on the <see cref="IView"/> minimum/maximum width or height constraints
+    /// </summary>
+    /// <param name="dimension"></param>
+    /// <param name="byWidth">
+    /// true to constrain the value based on the <see cref="IView.MinimumWidth"/>
+    /// and <see cref="IView.MaximumWidth"/>; 
+    /// otherwise, false to constrain the value based on the <see cref="IView.MinimumHeight"/>
+    /// and <see cref="IView.MaximumHeight"/>
+    /// </param>
+    /// <returns>
+    /// The constrained value.
+    /// </returns>
+    public double Constrain(double dimension, bool byWidth)
+    {
+        double minimum = byWidth ? View.MinimumWidth : View.MinimumHeight;
+        double maximum = byWidth ? View.MaximumWidth : View.MaximumHeight;
+
+        if (IsDefined(minimum))
+        {
+            dimension = Math.Max(minimum, dimension);
+        }
+        if (IsDefined(maximum))
+        {
+            dimension = Math.Min(maximum, dimension);
+        }
+        return dimension;
+    }
+
+    /// <summary>
+    /// Determines if a value is defined.
+    /// </summary>
+    /// <param name="value">the value to check.</param>
+    /// <returns>true if the value greater than or equal to zero and is finite.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsDefined(double value)
+    {
+        return !double.IsNaN(value) && !double.IsInfinity(value) && value > 0;
+    }
+
+}

--- a/Controls/Layouts/LayoutManager.cs
+++ b/Controls/Layouts/LayoutManager.cs
@@ -1,0 +1,84 @@
+﻿namespace GlyphViewer.Controls.Layouts;
+
+using Microsoft.Maui.Layouts;
+
+/// <summary>
+/// Provides an abstract <see cref="LayoutManager"/> base class.
+/// </summary>
+/// <typeparam name="C">The layout <see cref="Container"/>.</typeparam>
+/// <typeparam name="I">The <see cref="LayoutInfo"/> used to layout items.</typeparam>
+public abstract class LayoutManager<C, I> : LayoutManager
+    where C : Layout<I>
+    where I : LayoutInfo
+{
+    /// <summary>
+    /// Initializes a new instance of this class.
+    /// </summary>
+    /// <param name="layout">The <see cref="Container"/> <see cref="Layout{I}"/></param>
+    protected LayoutManager(C layout)
+        : base(layout)
+    {
+        Container = layout;
+    }
+
+    /// <summary>
+    /// Gets the containing <see cref="Layout{I}"/>.
+    /// </summary>
+    protected C Container
+    {
+        get;
+    }
+
+    #region Overrides
+
+    /// <summary>
+    /// Measures the child items.
+    /// </summary>
+    /// <param name="widthConstraint">The width constraint.</param>
+    /// <param name="heightConstraint">The height constraint.</param>
+    /// <returns>The measured <see cref="Size"/> for the content.</returns>
+    public override Size Measure(double widthConstraint, double heightConstraint)
+    {
+        Size size;
+        if (Container.Children.Count > 0)
+        {
+            size = MeasureContent(widthConstraint, heightConstraint);
+        }
+        else
+        {
+            size = Size.Zero;
+        }
+        return size;
+    }
+
+    /// <summary>
+    /// Arranges content in the specified <see cref="Rect"/>.
+    /// </summary>
+    /// <param name="bounds">The <see cref="Rect"/> to use to arrange the content.</param>
+    /// <returns>The consumed <see cref="Size"/>.</returns>
+    public override Size ArrangeChildren(Rect bounds)
+    {
+        return ArrangeContent(bounds);
+    }
+
+    #endregion Overrides
+
+    #region Abstract Methods
+
+    /// <summary>
+    /// Implemented in the derived class to measure child items.
+    /// </summary>
+    /// <param name="widthConstraint">The width constraint.</param>
+    /// <param name="heightConstraint">The height constraint.</param>
+    /// <returns>The required <see cref="Size"/> for the content.</returns>
+    protected abstract Size MeasureContent(double widthConstraint, double heightConstraint);
+
+    /// <summary>
+    /// Implemented in the derived class to arrange content.
+    /// </summary>
+    /// <param name="bounds">The <see cref="Rect"/> to use to arrange the content.</param>
+    /// <returns>The consumed <see cref="Size"/>.</returns>
+    protected abstract Size ArrangeContent(Rect bounds);
+
+    #endregion Abstract Methods
+}

--- a/Controls/SkLabel.cs
+++ b/Controls/SkLabel.cs
@@ -12,7 +12,7 @@ internal class SkLabel : SKCanvasView
     static readonly Color DefaultTextColor = Colors.Black;
     const double DefaultFontSize = 12;
     const double MinimumFontSize = 6;
-    static readonly FontFamily DefaultFontFamily = FontFamily.DefaultFontFamily;
+    static readonly FontFamily DefaultFontFamily = FontFamily.Default;
 
     const FontAttributes DefaultFontAttributes = FontAttributes.None;
 
@@ -67,7 +67,7 @@ internal class SkLabel : SKCanvasView
         InvalidateSurface();
     }
 
-    #endregion ItemColor
+    #endregion Text
 
     #region TextColor
 
@@ -104,7 +104,7 @@ internal class SkLabel : SKCanvasView
         }
     );
 
-    #endregion ItemColor
+    #endregion TextColor
 
     #region FontFamily
 
@@ -125,7 +125,7 @@ internal class SkLabel : SKCanvasView
         nameof(FontFamily),
         typeof(FontFamily),
         typeof(SkLabel),
-        FontFamily.DefaultFontFamily,
+        FontFamily.Default,
         BindingMode.OneWay,
         coerceValue: (bindable, value) =>
         {

--- a/Controls/Slider/Slider.cs
+++ b/Controls/Slider/Slider.cs
@@ -78,7 +78,7 @@ public sealed class Slider : SKCanvasView
         {
             InvalidateSurface();
         }
-        base.OnPropertyChanging(propertyName);
+        base.OnPropertyChanged(propertyName);
     }
 
     /// <summary>
@@ -164,16 +164,7 @@ public sealed class Slider : SKCanvasView
             if (bindableObject is Slider slider)
             {
                 double value = SliderDrawable.Round((double)newValue, slider.Interval);
-
-                if (value < slider.Minimum + slider.Interval)
-                {
-                    value = slider.Minimum;
-                }
-                else if (value > slider.Maximum - slider.Interval)
-                {
-                    value = slider.Maximum;
-                }
-                return value;
+                newValue = Math.Clamp(value, slider.Minimum, slider.Maximum);
             }
             return newValue;
         },

--- a/Controls/SliderView/SliderCommand.cs
+++ b/Controls/SliderView/SliderCommand.cs
@@ -1,0 +1,34 @@
+﻿namespace GlyphViewer.Controls;
+
+using GlyphViewer.ObjectModel;
+
+/// <summary>
+/// Provides a command for the <see cref="SliderView"/> control to handle previous and next actions.
+/// </summary>
+internal sealed class SliderCommand : Command
+{
+    /// <summary>
+    /// Initializes a new instance of this class.
+    /// </summary>
+    /// <param name="action">The <see cref="Action"/> to perform.</param>
+    /// <param name="isNext">true if the command increments the <see cref="Slider.Value"/>; otherwise, 
+    /// false if it decrements the <see cref="Slider.Value"/></param>
+    public SliderCommand(Action action, bool isNext)
+        : base(action)
+    {
+        IsNext = isNext;
+        IsEnabled = false;
+    }
+
+    /// <summary>
+    /// Gets the value indicating whether this command increments the <see cref="Slider.Value"/>.
+    /// </summary>
+    /// <value>
+    /// true if the command increments the <see cref="Slider.Value"/>; otherwise, 
+    /// false if it decrements the <see cref="Slider.Value"/>
+    /// </value>
+    public bool IsNext
+    {
+        get;
+    }
+}

--- a/Controls/SliderView/SliderView.xaml
+++ b/Controls/SliderView/SliderView.xaml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:GlyphViewer.Controls"
+             xmlns:text="clr-namespace:GlyphViewer.Text"
+             x:Class="GlyphViewer.Controls.SliderView"
+             >
+
+    <ContentView.Resources>
+        <Style TargetType="Button" x:Key="SliderButtonStyle"
+               BasedOn="{StaticResource GlyphButtonStyle}">
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="FontSize" Value="40"/>
+            <Setter Property="Margin" Value="0"/>
+            <Setter Property="MinimumHeightRequest" Value="20"/>
+            <Setter Property="MinimumWidthRequest" Value="20"/>
+        </Style>
+    </ContentView.Resources>
+
+    <controls:Toolbar x:DataType="controls:SliderView"
+                      BindingContext="{Binding Source={RelativeSource AncestorType={x:Type controls:SliderView}}, x:DataType=controls:SliderView, Path=Context}" 
+                      Orientation="{Binding Orientation}"
+                      ItemSpacing="2">
+
+        <Button x:Name="PreviousButton"
+                x:DataType="controls:SliderView"
+                Style="{StaticResource SliderButtonStyle}"
+                Command="{Binding PreviousCommand}"
+                controls:Toolbar.Alignment="Start"
+                />
+
+        <controls:Slider x:Name="Slider" 
+                         x:DataType="controls:SliderView"
+                         Value="{Binding Value, Mode=TwoWay}"
+                         Minimum="{Binding Minimum}"
+                         Maximum="{Binding Maximum}"
+                         Interval="{Binding Interval}"
+                         IsEnabled="{Binding IsEnabled}"
+                         Orientation="{Binding Orientation}"
+                         controls:Toolbar.Alignment="CenterFill"
+                         />
+
+        <Button x:Name="NextButton"
+                x:DataType="controls:SliderView"
+                Style="{StaticResource SliderButtonStyle}"
+                Command="{Binding NextCommand}"
+                controls:Toolbar.Alignment="End"
+                />
+        
+    </controls:Toolbar>
+</ContentView>

--- a/Controls/SliderView/SliderView.xaml.cs
+++ b/Controls/SliderView/SliderView.xaml.cs
@@ -1,0 +1,266 @@
+namespace GlyphViewer.Controls;
+
+using GlyphViewer.ObjectModel;
+using GlyphViewer.Resources;
+
+public partial class SliderView : ContentView
+{
+    public SliderView()
+	{
+        NextCommand = new(OnNext)
+        {
+            IsEnabled = false
+        };
+        PreviousCommand = new(OnPrevious)
+        {
+           IsEnabled = false
+        };
+        InitializeComponent();
+
+        Slider.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(Slider.Value) ||
+                e.PropertyName == nameof(Slider.Minimum) ||
+                e.PropertyName == nameof(Slider.Maximum))
+            {
+                UpdateButtons();
+            }
+        };
+    }
+
+    #region Properties
+
+    public SliderView Context
+    {
+        get => this;
+    }
+
+    /// <summary>
+    /// Gets the command to decrease the <see cref="Slider.Value"/>.
+    /// </summary>
+    public Command PreviousCommand
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets the command to increase the <see cref="Slider.Value"/>.
+    /// </summary>
+    public Command NextCommand
+    {
+        get;
+    }
+
+    // TODO: Determine if there is a better way to reflect the Slider properties
+    // instead of duplicating them.
+
+    #region Value
+
+    /// <summary>
+    /// Gets or sets value.
+    /// </summary>
+    /// <value>
+    /// A double value in the range of 0 to 100f.
+    /// </value>
+    public double Value
+    {
+        get => (double)GetValue(ValueProperty);
+        set => SetValue(ValueProperty, value);
+    }
+
+    /// <summary>
+    /// Provides the <see cref="BindableProperty"/> for <see cref="Value"/>.
+    /// </summary>
+    public static readonly BindableProperty ValueProperty = BindableProperty.Create
+    (
+        nameof(Value),
+        typeof(double),
+        typeof(SliderView),
+        0.0,
+        BindingMode.TwoWay
+    );
+
+    #endregion Value
+
+    #region Interval
+
+    /// <summary>
+    /// Gets or sets the value to use to increase or decrease the <see cref="Value"/>
+    /// </summary>
+    /// <value>
+    /// A double value in the range of 0 to 100f.
+    /// </value>
+    /// <remarks>
+    /// When this property is greater than zero, the <see cref="Value"/> is rounded
+    /// to the nearest interval.
+    /// </remarks>
+    public double Interval
+    {
+        get => (double)GetValue(IntervalProperty);
+        set => SetValue(IntervalProperty, value);
+    }
+
+    /// <summary>
+    /// Provides the <see cref="BindableProperty"/> for <see cref="Interval"/>.
+    /// </summary>
+    public static readonly BindableProperty IntervalProperty = BindableProperty.Create
+    (
+        nameof(Interval),
+        typeof(double),
+        typeof(SliderView),
+        1.0
+    );
+
+    #endregion Interval
+
+    #region Minimum
+
+    /// <summary>
+    /// Gets or sets the minimum <see cref="Value"/>.
+    /// </summary>
+    /// <value>
+    /// A double value in the range of 0 to 100f.
+    /// </value>
+    public double Minimum
+    {
+        get => (double)GetValue(MinimumProperty);
+        set => SetValue(MinimumProperty, value);
+    }
+
+    /// <summary>
+    /// Provides the <see cref="BindableProperty"/> for <see cref="Minimum"/>.
+    /// </summary>
+    public static readonly BindableProperty MinimumProperty = BindableProperty.Create
+    (
+        nameof(Minimum),
+        typeof(double),
+        typeof(SliderView),
+        0.0
+    );
+
+    #endregion Minimum
+
+    #region Maximum
+
+    /// <summary>
+    /// Gets or sets the maximum <see cref="Value"/>.
+    /// </summary>
+    /// <value>
+    /// A double value in the range of 0 to 100f.
+    /// </value>
+    public double Maximum
+    {
+        get => (double)GetValue(MaximumProperty);
+        set => SetValue(MaximumProperty, value);
+    }
+
+    /// <summary>
+    /// Provides the <see cref="BindableProperty"/> for <see cref="Maximum"/>.
+    /// </summary>
+    public static readonly BindableProperty MaximumProperty = BindableProperty.Create
+    (
+        nameof(Maximum),
+        typeof(double),
+        typeof(SliderView),
+        double.MaxValue
+    );
+    #endregion Maximum
+
+    #region ThumbStyle
+
+    /// <summary>
+    /// Gets or sets the maximum <see cref="Value"/>.
+    /// </summary>
+    /// <value>
+    /// A double value in the range of 0 to 100f.
+    /// </value>
+    public ThumbStyle ThumbStyle
+    {
+        get => (ThumbStyle)GetValue(ThumbStyleProperty);
+        set => SetValue(ThumbStyleProperty, value);
+    }
+
+    /// <summary>
+    /// Provides the <see cref="BindableProperty"/> for <see cref="ThumbStyle"/>.
+    /// </summary>
+    public static readonly BindableProperty ThumbStyleProperty = BindableProperty.Create
+    (
+        nameof(ThumbStyle),
+        typeof(ThumbStyle),
+        typeof(SliderView),
+        ThumbStyle.Circle
+     );
+
+    #endregion ThumbStyle
+
+    #region Orientation
+
+    /// <summary>
+    /// Gets or sets the <see cref="StackOrientation"/> of the thumb.
+    /// </summary>
+    public StackOrientation Orientation
+    {
+        get => (StackOrientation)GetValue(OrientationProperty);
+        set => SetValue(OrientationProperty, value);
+    }
+
+    /// <summary>
+    /// Provides the <see cref="BindableProperty"/> for <see cref="Orientation"/>.
+    /// </summary>
+    public static readonly BindableProperty OrientationProperty = BindableProperty.Create
+    (
+        nameof(Orientation),
+        typeof(StackOrientation),
+        typeof(SliderView),
+        Slider.DefaultOrientation
+    );
+
+    #endregion Orientation   
+
+    #endregion Properties
+
+    #region Methods
+
+    /// <summary>
+    /// Advances the slider's value by its interval, up to the maximum value.
+    /// </summary>
+    void OnNext()
+    {
+        SetSliderValue(Slider.Interval);
+    }
+
+    /// <summary>
+    /// Decreases the slider's value by its interval, ensuring the value does not go below the minimum.
+    /// </summary>
+    void OnPrevious()
+    {
+        SetSliderValue(-Slider.Interval);
+    }
+
+    void SetSliderValue(double interval)
+    {
+        double value = Math.Clamp(Slider.Value + interval, Slider.Minimum, Slider.Maximum);
+        if (value != Slider.Value)
+        {
+            Slider.Value = value;
+        }
+    }
+
+    void UpdateButtons()
+    {
+        PreviousCommand.IsEnabled = Value > Minimum;
+        NextCommand.IsEnabled = Value < Maximum;
+        if (Orientation == StackOrientation.Horizontal)
+        {
+            NextButton.Text = FluentUI.CaretRightFilled;
+            PreviousButton.Text = FluentUI.CaretLeftFilled;
+        }
+        else
+        {
+            NextButton.Text = FluentUI.CaretDownFilled;
+            PreviousButton.Text = FluentUI.CaretUpFilled;
+        }
+    }
+
+    #endregion Methods
+}

--- a/Controls/Toolbar/Toolbar.cs
+++ b/Controls/Toolbar/Toolbar.cs
@@ -1,0 +1,169 @@
+﻿namespace GlyphViewer.Controls;
+
+using GlyphViewer.Controls.Layouts;
+using Microsoft.Maui;
+using Microsoft.Maui.Layouts;
+using System.ComponentModel;
+
+/// <summary>
+/// Provides a layout manager for a vertical or horizontal tool bar.
+/// </summary>
+public sealed class Toolbar : Layout<ToolbarLayoutInfo>
+{
+    /// <summary>
+    /// Creates an instance of <see cref="ToolbarLayoutInfo"/>.
+    /// </summary>
+    /// <param name="view">The <see cref="IView"/> to arrange.</param>
+    /// <returns>A new instance of a <see cref="ToolbarLayoutInfo"/>.</returns>
+    protected override ToolbarLayoutInfo CreateItemInfo(IView view)
+    {
+        if (view is BindableObject bindable)
+        {
+            ToolbarAlignment alignment = GetAlignment(bindable);
+            return new ToolbarLayoutInfo(view, alignment);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Creates a layout manager for arranging the toolbar items.
+    /// </summary>
+    /// <returns>A new instance of a <see cref="ToolbarLayoutManager"/>.</returns>
+    protected override ILayoutManager CreateLayoutManager()
+    {
+        return new ToolbarLayoutManager(this);
+    }
+
+    #region Alignment Attached Property
+
+    /// <summary>
+    /// Defines an attached property for arranging a child <see cref="IView"/> in a <see cref="Toolbar"/>.
+    /// </summary>
+    [TypeConverter(typeof(ToolbarAlignmentTypeConverter))]
+    public static readonly BindableProperty AlignmentProperty = BindableProperty.CreateAttached
+    (
+        nameof(ToolbarAlignment),
+        typeof(ToolbarAlignment),
+        typeof(Toolbar),
+        ToolbarAlignment.Start,
+        propertyChanged: (bindableObject, oldValue, newValue) =>
+        {
+            if (bindableObject is View view && view.Parent is Toolbar toolbar)
+            {
+                toolbar.OnAlignmentChanged(view, (ToolbarAlignment)newValue);
+            }
+        }
+    );
+
+    /// <summary>
+    /// Gets the <see cref="ToolbarAlignment"/> o use to arrange the item in a <see cref="Toolbar"/>.
+    /// </summary>
+    /// <param name="bindable">A visual element.</param>
+    /// <returns>The <see cref="ToolbarAlignment"/>.</returns>
+    [TypeConverter(typeof(ToolbarAlignmentTypeConverter))]
+    public static ToolbarAlignment GetAlignment(BindableObject bindable)
+    {
+        return (ToolbarAlignment)bindable.GetValue(AlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets the layout bounds of a child element that will be arrange it..
+    /// </summary>
+    /// <param name="bindable">The view to delimit by bounds.</param>
+    /// <param name="alignment">An <see cref="ToolbarAlignment"/> to use to arrange the item in a <see cref="Toolbar"/>.</param>
+    public static void SetAlignment(BindableObject bindable, ToolbarAlignment alignment)
+    {
+        bindable.SetValue(AlignmentProperty, alignment);
+    }
+
+    void OnAlignmentChanged(View child, ToolbarAlignment value)
+    {
+        if (this[child] is ToolbarLayoutInfo info)
+        {
+            info.Alignment = value;
+            if (info.NeedsMeasure)
+            {
+                InvalidateMeasure();
+            }
+        }
+    }
+
+    #endregion Alignment Attached Property
+
+    #region ItemSpacing
+
+    /// <summary>
+    /// Defines the default <see cref="ItemSpacing"/>.
+    /// </summary>
+    public const double DefaultItemSpacing = 1.0;
+
+    /// <summary>
+    /// Gets or sets the item spacing for toolbar items.
+    /// </summary>
+    /// <value>
+    /// The zero-based item spacing.
+    /// <para>
+    /// The default value is <see cref="DefaultItemSpacing"/>.
+    /// </para>
+    /// </value>
+    public double ItemSpacing
+    {
+        get => (double)GetValue(ItemSpacingProperty);
+        set => SetValue(ItemSpacingProperty, value);
+    }
+
+    /// <summary>
+    /// Provides the <see cref="BindableProperty"/> for <see cref="ItemSpacing"/>.
+    /// </summary>
+    public static readonly BindableProperty ItemSpacingProperty = BindableProperty.Create
+    (
+        nameof(ItemSpacing),
+        typeof(double),
+        typeof(Toolbar),
+        DefaultItemSpacing,
+        validateValue: (bindableObject, newValue) =>
+        {
+            return ((double)newValue >= 0);
+        },
+        propertyChanged: (bindableObject, oldValue, newValue) =>
+        {
+            if (bindableObject is Toolbar toolbar)
+            {
+                toolbar.InvalidateMeasure();
+            }
+        }
+    );
+
+    #endregion ItemSpacing
+
+    #region Orientation
+
+    /// <summary>
+    /// Gets or sets the <see cref="StackOrientation"/> of the toolbar.
+    /// </summary>
+    public StackOrientation Orientation
+    {
+        get => (StackOrientation)GetValue(OrientationProperty);
+        set => SetValue(OrientationProperty, value);
+    }
+
+    /// <summary>
+    /// Provides the <see cref="BindableProperty"/> for <see cref="Orientation"/>.
+    /// </summary>
+    public static readonly BindableProperty OrientationProperty = BindableProperty.Create
+    (
+        nameof(Orientation),
+        typeof(StackOrientation),
+        typeof(Toolbar),
+        StackOrientation.Horizontal,
+        propertyChanged: (bindableObject, oldValue, newValue) =>
+        {
+            if (bindableObject is Toolbar toolbar)
+            {
+                toolbar.InvalidateMeasure();
+            }
+        }
+    );
+
+    #endregion Orientation
+}

--- a/Controls/Toolbar/ToolbarAlignment.cs
+++ b/Controls/Toolbar/ToolbarAlignment.cs
@@ -1,0 +1,27 @@
+﻿namespace GlyphViewer.Controls;
+
+/// <summary>
+/// Defines the layout region for a toolbar item.
+/// </summary>
+public enum ToolbarAlignment
+{
+    /// <summary>
+    /// The item is aligned at the start of the <see cref="Toolbar"/>.
+    /// </summary>
+    Start = 1,
+
+    /// <summary>
+    /// The item is aligned at the center of the <see cref="Toolbar"/>.
+    /// </summary>
+    Center = 2,
+
+    /// <summary>
+    /// The item is aligned at the center of the <see cref="Toolbar"/> and fills the available space.
+    /// </summary>
+    CenterFill = 3,
+
+    /// <summary>
+    /// The item is aligned at the end of the <see cref="Toolbar"/>.
+    /// </summary>
+    End = 4
+}

--- a/Controls/Toolbar/ToolbarAlignmentTypeConverter.cs
+++ b/Controls/Toolbar/ToolbarAlignmentTypeConverter.cs
@@ -1,0 +1,45 @@
+﻿namespace GlyphViewer.Controls;
+
+using GlyphViewer.Converter;
+using System.Globalization;
+
+/// <summary>
+/// Provides a <see cref="IValueConverter"/> for converting between <see cref="ToolbarAlignment"/> values and their string representations.
+/// </summary>
+public sealed class ToolbarAlignmentTypeConverter : TypeConverter<ToolbarAlignment, String>
+{
+    /// <summary>
+    /// Defines an instance of a <see cref="ToolbarAlignmentTypeConverter"/>.
+    /// </summary>
+    public static readonly ToolbarAlignmentTypeConverter Converter = new();
+
+    /// <summary>
+    /// Converts a string representation of an <see cref="ToolbarAlignment"/> value to its corresponding enum value.
+    /// </summary>
+    /// <param name="culture">Not used.</param>
+    /// <param name="value">The string value to convert.</param>
+    /// <returns>An <see cref="ToolbarAlignment"/> value.</returns>
+    /// <exception cref="FormatException"><paramref name="value"/> is not a valid <see cref="ToolbarAlignment"/> string.</exception>
+    protected override ToolbarAlignment ConvertFrom(CultureInfo culture, string value)
+    {
+        if (!Enum.TryParse(value, out ToolbarAlignment alignment))
+        {
+            throw new FormatException
+            (
+                string.Format($"'{value}' is not a valid Alignment value")
+            );
+        }
+        return alignment;
+    }
+
+    /// <summary>
+    /// Converts an <see cref="ToolbarAlignment"/> value to its string representation.
+    /// </summary>
+    /// <param name="culture">Not used.</param>
+    /// <param name="value">The <see cref="ToolbarAlignment"/> to convert.</param>
+    /// <returns>A string representation of the <paramref name="value"/>.</returns>
+    protected override string ConvertTo(CultureInfo culture, ToolbarAlignment value)
+    {
+        return Enum.GetName<ToolbarAlignment>(value);
+    }
+}

--- a/Controls/Toolbar/ToolbarLayoutInfo.cs
+++ b/Controls/Toolbar/ToolbarLayoutInfo.cs
@@ -1,0 +1,35 @@
+﻿namespace GlyphViewer.Controls;
+/// <summary>
+/// Defines the positioning of an item in a <see cref="Toolbar"/>.
+/// </summary>
+public sealed class ToolbarLayoutInfo : LayoutInfo
+{
+    ToolbarAlignment _alignment;
+
+    /// <summary>
+    /// Initializes a new instance of this class.
+    /// </summary>
+    /// <param name="view">The <see cref="IView"/> to arrange.</param>
+    /// <param name="alignment">The <see cref="Alignment"/> of the toolbar item.</param>
+    public ToolbarLayoutInfo(IView view, ToolbarAlignment alignment) 
+        : base(view)
+    {
+        _alignment = alignment;
+    }
+
+    /// <summary>
+    /// Determines the alignment of the toolbar item in the toolbar.
+    /// </summary>
+    public ToolbarAlignment Alignment
+    {
+        get => _alignment;
+        set
+        {
+            if (_alignment != value)
+            {
+                _alignment = value;
+                NeedsMeasure = true;
+            }
+        }
+    }
+}

--- a/Controls/Toolbar/ToolbarLayoutManager.cs
+++ b/Controls/Toolbar/ToolbarLayoutManager.cs
@@ -1,0 +1,394 @@
+﻿namespace GlyphViewer.Controls;
+
+using GlyphViewer.Controls.Layouts;
+using System.Runtime.CompilerServices;
+
+/// <summary>
+/// Provides a layout manager for arranging toolbar items in a <see cref="Toolbar"/> control.
+/// </summary>
+internal sealed class ToolbarLayoutManager : LayoutManager<Toolbar, ToolbarLayoutInfo>
+{
+    readonly Toolbar _layout;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ToolbarLayoutManager"/> class.
+    /// </summary>
+    /// <param name="layout">The containing <see cref="Toolbar"/>.</param>
+    public ToolbarLayoutManager(Toolbar layout) 
+        : base(layout)
+    {
+        _layout = layout;
+    }
+
+    /// <summary>
+    /// Measures the size of the toolbar content based on the available constraints.
+    /// </summary>
+    /// <param name="widthConstraint">The width constriant.</param>
+    /// <param name="heightConstraint">The height constraint.</param>
+    /// <returns>The size needed to arrange the child items.</returns>
+    protected override Size MeasureContent(double widthConstraint, double heightConstraint)
+    {
+        Thickness padding = Container.Padding;
+        bool isHorizontal = Container.Orientation == StackOrientation.Horizontal;
+
+        double availableWidth = widthConstraint;
+        double availableHeight = heightConstraint;
+
+        double measuredWidth = 0;
+        double measuredHeight = 0;
+
+        int count = 0;
+        foreach (IView view in Container.Children)
+        {
+            if (view is null || view.Visibility == Visibility.Collapsed)
+            {
+                continue;
+            }
+
+            ToolbarLayoutInfo info = Container[view];
+            if (info is null)
+            {
+                continue;
+            }
+            if (info.NeedsMeasure)
+            {
+                double height = availableHeight;
+                double width = availableWidth;
+               info.Measure(width, height);
+            }
+            if (isHorizontal)
+            {
+                if (info.Height > measuredHeight)
+                {
+                    measuredHeight = info.Height;
+                }
+                measuredWidth += info.Width;
+            }
+            else
+            {
+                measuredWidth = Math.Max(measuredWidth, info.Width);
+                measuredHeight += info.Height;
+            }
+            count++;
+        }
+
+        count--;
+        double spacing = count * Container.ItemSpacing;
+        if (isHorizontal)
+        {
+            measuredWidth += spacing;
+        }
+        else
+        {
+            measuredHeight += spacing;
+        }
+
+        return new Size
+        (
+            measuredWidth + padding.HorizontalThickness,
+            measuredHeight + padding.VerticalThickness
+        );
+    }
+
+    /// <summary>
+    /// Arranges the toolbar content within the specified bounds.
+    /// </summary>
+    /// <param name="bounds">The <see cref="Rect"/> defining the bounds.</param>
+    /// <returns>The size used to arrange the content.</returns>
+    protected override Size ArrangeContent(Rect bounds)
+    {
+        Thickness padding = Container.Padding;
+        bool isHorizontal = Container.Orientation == StackOrientation.Horizontal;
+
+        Rect layoutRect = new Rect
+        (
+            padding.Left, padding.Top,
+            bounds.Width - padding.HorizontalThickness,
+            bounds.Height - padding.VerticalThickness
+        );
+
+        List<ToolbarLayoutInfo> start = [];
+        List<ToolbarLayoutInfo> end = [];
+        List<ToolbarLayoutInfo> center = [];
+
+        double startDimension = 0.0;
+        double centerDimension = 0.0;
+        double endDimension = 0.0;
+        double spacing = Container.ItemSpacing;
+        int fillCount = 0;
+
+        // Calculate the size of each layout region (Start, Center, End)
+        foreach (IView view in Container.Children)
+        {
+            if (view is null || view.Visibility == Visibility.Collapsed)
+            {
+                continue;
+            }
+
+            if (Container[view] is not ToolbarLayoutInfo info)
+            {
+                continue;
+            }
+            switch (info.Alignment)
+            {
+                case ToolbarAlignment.Start:
+                    start.Add(info);
+                    startDimension += ItemDimension(info, spacing, isHorizontal);
+                    break;
+
+                case ToolbarAlignment.Center:
+                case ToolbarAlignment.CenterFill:
+                    center.Add(info);
+                    centerDimension += ItemDimension(info, spacing, isHorizontal);
+                    if (info.Alignment == ToolbarAlignment.CenterFill)
+                    {
+                        fillCount++;
+                    }
+                    break;
+
+                case ToolbarAlignment.End:
+                    end.Add(info);
+                    endDimension += ItemDimension(info, spacing, isHorizontal);
+                    break;
+            }
+        }
+
+        // Trim the spacing from last item
+        // in each group.
+        startDimension -= spacing;
+        centerDimension -= spacing;
+        endDimension -= spacing;
+
+        //
+        // Arrange the Start items.
+        //
+        double x = layoutRect.Left;
+        double y = layoutRect.Top;
+        double width = isHorizontal ? startDimension : layoutRect.Width;
+        double height = isHorizontal ? layoutRect.Height : startDimension;
+
+        ArrangeItems(start, isHorizontal, x, y, width, height, spacing, layoutRect);
+
+        //
+        // Arrange the End items.
+        //
+        if (isHorizontal)
+        {
+            x = layoutRect.Right - endDimension;
+            width = endDimension;
+        }
+        else
+        {
+            y = layoutRect.Bottom - endDimension;
+            height = endDimension;
+        }
+        ArrangeItems(end, isHorizontal, x, y, width, height, spacing, layoutRect);
+
+        if (isHorizontal)
+        {
+            width = layoutRect.Width - (startDimension + endDimension);
+        }
+        else
+        {
+            height = layoutRect.Height - (startDimension - endDimension);
+        }
+
+        if (fillCount > 0)
+        {
+            if (isHorizontal)
+            {
+                width = layoutRect.Width - (startDimension + endDimension);
+                x = layoutRect.Left + startDimension;
+            }
+            else
+            {
+                height = layoutRect.Height - (startDimension + endDimension);
+                y = layoutRect.Top + startDimension;
+            }
+
+            // If there are fill items
+            ArrangeCenterItems(center, isHorizontal, x, y, width, height, spacing, layoutRect);
+            return bounds.Size;
+        }
+        else
+        {
+            if (isHorizontal)
+            {
+                x = (layoutRect.Width - centerDimension) / 2;
+                width = centerDimension;
+            }
+            else
+            {
+                y = (layoutRect.Height - centerDimension) / 2;
+                height = centerDimension;
+            }
+            ArrangeItems(center, isHorizontal, x, y, width, height, spacing, layoutRect);
+        }
+        return bounds.Size;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static double ItemDimension(ToolbarLayoutInfo info, double spacing, bool isHorizontal)
+    {
+        return spacing + (isHorizontal ? info.Width : info.Height);
+    }
+
+    /// <summary>
+    /// Arrange the toolbar items in the center when one or more items are marked<see cref="ToolbarAlignment.CenterFill"/>
+    /// </summary>
+    /// <param name="items">The <see cref="ToolbarLayoutInfo"/> for the region.</param>
+    /// <param name="isHorizontal">true if the toolbar is horizontal; otherwise, false.</param>
+    /// <param name="x">The X coordinate of the region.</param>
+    /// <param name="y">The Y coordinate of the region.</param>
+    /// <param name="width">The width of the region.</param>
+    /// <param name="height">The height of the region.</param>
+    /// <param name="spacing">The spacing between items.</param>
+    /// <param name="bounds">The overall bounds of the toolbar.</param>
+    static void ArrangeCenterItems
+    (
+        List<ToolbarLayoutInfo> items, bool isHorizontal,
+        double x, double y,
+        double width, double height,
+        double spacing,
+        Rect bounds
+    )
+    {
+        int fillCount = 0;
+        double fillDimension = isHorizontal ? width : height;
+
+        // calculate how much space is available for fill items
+        for (int i = 0; i < items.Count; i++)
+        {
+            ToolbarLayoutInfo info = items[i];
+            if (info.Alignment == ToolbarAlignment.CenterFill)
+            {
+                fillCount++;
+            }
+            else
+            { 
+                fillDimension -= isHorizontal ? info.Width : info.Height;
+                if (i < items.Count - 1)
+                {
+                    fillDimension -= spacing;
+                }
+            }   
+        }
+
+        // Distribute the remaining space evenly for fill items
+        fillDimension = fillDimension / fillCount;
+
+        // Arrange the items.
+        for (int i = 0; i < items.Count; i++)
+        {
+            ToolbarLayoutInfo info = items[i];
+            if (info.Alignment == ToolbarAlignment.CenterFill)
+            {
+                double itemWidth = isHorizontal ? fillDimension : width;
+                double itemHeight = isHorizontal ? height : fillDimension;
+                ArrangeItem(info, isHorizontal, x, y, itemWidth, itemHeight, bounds);
+            }
+            else
+            {
+                ArrangeItem(info, isHorizontal, x, y, width, height, bounds);
+            }
+            if (i == items.Count - 1)
+            {
+                // Don't add spacing after the last item
+                break;
+            }
+            if (isHorizontal)
+            {
+                x = info.Bounds.Right + spacing;
+                width -= info.Bounds.Width + spacing;
+            }
+            else
+            {
+                y = info.Bounds.Bottom + spacing;
+                height -= info.Bounds.Height + spacing;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Arrange the toolbar items.
+    /// </summary>
+    /// <param name="items">The <see cref="ToolbarLayoutInfo"/> for the region.</param>
+    /// <param name="isHorizontal">true if the toolbar is horizontal; otherwise, false.</param>
+    /// <param name="x">The X coordinate of the region.</param>
+    /// <param name="y">The Y coordinate of the region.</param>
+    /// <param name="width">The width of the region.</param>
+    /// <param name="height">The height of the region.</param>
+    /// <param name="spacing">The spacing between items.</param>
+    /// <param name="bounds">The overall bounds of the toolbar.</param>
+    static void ArrangeItems
+    (
+        List<ToolbarLayoutInfo> items, bool isHorizontal,
+        double x, double y,
+        double width, double height,
+        double spacing,
+        Rect bounds
+    )
+    {
+        for (int i = 0; i < items.Count; i++)
+        {
+            ToolbarLayoutInfo info = items[i];
+            ArrangeItem(info, isHorizontal, x, y, width, height, bounds);
+
+            if (i == items.Count - 1)
+            {
+                // Don't add spacing after the last item
+                break;
+            }
+            if (isHorizontal)
+            {
+                x = info.Bounds.Right + spacing;
+                width -= info.Bounds.Width + spacing;
+            }
+            else
+            {
+                y = info.Bounds.Bottom + spacing;
+                height -= info.Bounds.Height + spacing;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Calculate the <see cref="LayoutInfo.Bounds"/> of a toolbar item.
+    /// </summary>
+    /// <param name="info">The <see cref="ToolbarLayoutInfo"/> to update.</param>
+    /// <param name="isHorizontal">true if the toolbar is horizontal; otherwise, false.</param>
+    /// <param name="x">The X coordinate of the item.</param>
+    /// <param name="y">The Y coordinate of the item.</param>
+    /// <param name="widthConstraint">The width of the layout region.</param>
+    /// <param name="heightConstraint">The height of the layout region.</param>
+    /// <returns>A <see cref="Rect"/> defining the bounds of the item.</returns>
+    static void ArrangeItem
+    (
+        ToolbarLayoutInfo info,
+        bool isHorizontal,
+        double x, double y,
+        double widthConstraint, double heightConstraint,
+        Rect layoutBounds
+    )
+    {
+        bool isFill = info.Alignment == ToolbarAlignment.CenterFill;
+
+        double actualWidth;
+        double actualHeight;
+
+        if (isHorizontal)
+        {
+            actualHeight = Math.Min(info.Height, heightConstraint);
+            y += (heightConstraint - actualHeight) / 2;
+            actualWidth = isFill ? widthConstraint : info.Width; 
+        }
+        else
+        {
+            actualWidth = Math.Min(info.Width, widthConstraint);
+            x += (widthConstraint - actualWidth) / 2;
+            actualHeight = isFill ? heightConstraint : info.Height;
+        }
+
+        info.Arrange(new Rect(x, y, actualWidth, actualHeight));
+    }
+}

--- a/Converter/TypeConverter.cs
+++ b/Converter/TypeConverter.cs
@@ -1,0 +1,118 @@
+﻿namespace GlyphViewer.Converter;
+
+using System.ComponentModel;
+using System.Globalization;
+
+/// <summary>
+/// Provides an abstract base class for a <see cref="TypeConverter"/>.
+/// </summary>
+/// <typeparam name="T">The target type to convert to (the type of this converter).</typeparam>
+/// <typeparam name="S">The source type to convert from.</typeparam>
+public abstract class TypeConverter<T, S> : TypeConverter
+{
+    /// <summary>
+    /// Returns whether this converter can convert an object of the given <paramref name="sourceType"/> to the
+    /// type of this converter, using the specified context.
+    /// </summary>
+    /// <param name="context">An <see cref="ITypeDescriptorContext"/> that provides a format context.</param>
+    /// <param name="sourceType"> A System.Type that represents the type you want to convert from.</param>
+    /// <returns>true if <paramref name="sourceType"/> is of type <typeparamref name="S"/>; otherwise, false.</returns>
+    public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+    {
+        return sourceType == typeof(S);
+    }
+
+    /// <summary>
+    /// Returns whether this converter can convert the object to the specified type.
+    /// </summary>
+    /// <param name="context">An <see cref="ITypeDescriptorContext"/> that provides a format context.</param>
+    /// <param name="destinationType">A Type that represents the type to convert to.</param>
+    /// <returns>true if the <paramref name="destinationType"/> is of type <typeparamref name="S"/>; otherwise, false.</returns>
+    public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+    {
+        return destinationType == typeof(S);
+    }
+
+    /// <summary>
+    /// Converts the given value to the type of this converter.
+    /// </summary>
+    /// <param name="context">An <see cref="ITypeDescriptorContext"/> that provides a format context.</param>
+    /// <param name="culture">The <see cref="CultureInfo"/> to use as the current culture.</param>
+    /// <param name="value">A <typeparamref name="S"/> to convert from.</param>
+    /// <returns>A <typeparamref name="T"/> value.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="value"/> is a null reference
+    /// -or-
+    /// <paramref name="culture"/> is a null reference.
+    /// </exception>
+    /// <exception cref="ArgumentException"><paramref name="value"/> is not a value of type <typeparamref name="S"/>.</exception>
+    public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        culture ??= CultureInfo.CurrentCulture;
+
+        if (value is S source)
+        {
+            return ConvertFrom(culture, source);
+        }
+
+        throw new ArgumentException
+        (
+            $"[{value.GetType().FullName}]'{value}' must be a {typeof(S).FullName}.",
+            nameof(value)
+        );
+    }
+
+    /// <summary>
+    /// Converts the given value object to the specified type.
+    /// </summary>
+    /// <param name="context">An <see cref="ITypeDescriptorContext"/> that provides a format context.</param>
+    /// <param name="culture">The <see cref="CultureInfo"/> to use as the current culture.</param>
+    /// <param name="value">The <typeparamref name="T"/> value to convert.</param>
+    /// <param name="destinationType">The Type to convert the value parameter to.</param>
+    /// <returns>An <see cref="int"/> value for the boolean value where 
+    /// true returns 1 and false returns 0.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="value"/> is a null reference
+    /// -or-
+    /// <paramref name="culture"/> is a null reference.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="destinationType"/> is not a <typeparamref name="S"/>
+    /// -or-
+    /// <paramref name="value"/> is not of type <typeparamref name="T"/>.
+    /// </exception>
+    public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        ArgumentNullException.ThrowIfNull(culture);
+        if (destinationType != typeof(S))
+        {
+            throw new ArgumentException($"{destinationType.FullName} must be a {typeof(S).FullName}", nameof(destinationType));
+        }
+
+        if (value is T target)
+        {
+            return ConvertTo(culture, target);
+        }
+        throw new ArgumentException($"Cannot convert a [{value.GetType().FullName}]'{value}' to a {typeof(T).FullName}", nameof(value));
+    }
+
+    /// <summary>
+    /// Overridden in the derived class to convert from the <typeparamref name="S"/> type
+    /// to the <typeparamref name="T"/> type; the type of this converter.
+    /// </summary>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <param name="value">The value to convert from.</param>
+    /// <returns>An object of type <typeparamref name="T"/>.</returns>
+    protected abstract T ConvertFrom(CultureInfo culture, S value);
+
+    /// <summary>
+    /// Overridden in the derived class to convert from the <typeparamref name="T"/> type, 
+    /// the type of this converter, to the <typeparamref name="S"/> type;
+    /// </summary>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <param name="value">The value to convert.</param>
+    /// <returns>An object of type <typeparamref name="S"/>.</returns>
+    protected abstract S ConvertTo(CultureInfo culture, T value);
+}

--- a/GlyphViewer.csproj
+++ b/GlyphViewer.csproj
@@ -112,6 +112,9 @@
 	  <MauiXaml Update="Controls\JumpList.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
+	  <MauiXaml Update="Controls\SliderView\SliderView.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="Views\FileFontsView.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -14,9 +14,6 @@ public static class MauiProgram
     public static MauiApp CreateMauiApp()
     {
         Trace.TraceFlags = TraceFlag.Application | TraceFlag.Navigation;
-#if (DEBUG)
-        Trace.TraceFlags |= TraceFlag.Font;
-#endif
 
         var builder = MauiApp.CreateBuilder();
         builder

--- a/Settings/ItemFontSetting.cs
+++ b/Settings/ItemFontSetting.cs
@@ -59,7 +59,7 @@ public sealed class ItemFontSetting : FontSetting
             nameof(UserSettings.ItemFont),
             Strings.ItemFontName,
             Strings.ItemFontDescription,
-            Text.FontFamily.FluentUIFontFamily, // NOTE: This is only used by PageSettings.
+            Text.FontFamily.FluentUI, // NOTE: This is only used by PageSettings.
             DefaultFontSize,
             MinimumFontSize,
             MaximumFontSize,

--- a/Settings/ItemHeaderFontSetting.cs
+++ b/Settings/ItemHeaderFontSetting.cs
@@ -30,7 +30,7 @@ public sealed class ItemHeaderFontSetting : FontSetting
     /// <summary>
     /// Define the default font family name.
     /// </summary>
-    public static readonly FontFamily DefaultFontFamily = Text.FontFamily.DefaultFontFamily;
+    public static readonly FontFamily DefaultFontFamily = Text.FontFamily.Default;
 
     /// <summary>
     /// Define the default <see cref="Microsoft.Maui.Controls.FontAttributes"/>.

--- a/Settings/Properties/FontFamilyProperty.cs
+++ b/Settings/Properties/FontFamilyProperty.cs
@@ -15,10 +15,10 @@ public sealed class FontFamilyProperty : SettingProperty<FontFamily>
     /// </summary>
     /// <param name="defaultValue">The <see cref="NamedValue{FontFamily}.DefaultValue"/>.
     /// <para>
-    /// The default value is <see cref="FontFamily.DefaultFontFamily"/>.
+    /// The default value is <see cref="FontFamily.Default"/>.
     /// </para></param>
     public FontFamilyProperty(FontFamily defaultValue = null)
-        : base(nameof(FontSetting.FontFamily), defaultValue ?? FontFamily.DefaultFontFamily, Strings.FamilyNameLabel, Strings.FamilyNameDescription)
+        : base(nameof(FontSetting.FontFamily), defaultValue ?? FontFamily.Default, Strings.FamilyNameLabel, Strings.FamilyNameDescription)
     {
     }
 

--- a/Settings/TitleFontSetting.cs
+++ b/Settings/TitleFontSetting.cs
@@ -27,7 +27,7 @@ public class TitleFontSetting : FontSetting
     /// <summary>
     /// Define the default font family name.
     /// </summary>
-    public static readonly FontFamily DefaultFontFamily = Text.FontFamily.DefaultFontFamily;
+    public static readonly FontFamily DefaultFontFamily = Text.FontFamily.Default;
 
     /// <summary>
     /// Define the default <see cref="Microsoft.Maui.Controls.FontAttributes"/>.

--- a/Text/FontFamily.cs
+++ b/Text/FontFamily.cs
@@ -45,12 +45,12 @@ public class FontFamily : IEquatable<FontFamily>
     /// <summary>
     /// Gets the default <see cref="FontFamily"/>
     /// </summary>
-    public static readonly FontFamily DefaultFontFamily;
+    public static readonly FontFamily Default;
 
     /// <summary>
     /// Gets the <see cref="FontFamily"/> for the <see cref="FluentUI"/> font.
     /// </summary>
-    public static readonly FontFamily FluentUIFontFamily;
+    public static readonly FontFamily FluentUI;
 
     #endregion Constants
 
@@ -60,8 +60,8 @@ public class FontFamily : IEquatable<FontFamily>
     {
         _fontFamilies = new(StringComparer.OrdinalIgnoreCase);
 
-        DefaultFontFamily = FontFamily.CreateInstance(FontResource.DefaultFontName);
-        FluentUIFontFamily = CreateInstance(FontResource.FluentUIName);
+        Default = CreateInstance(FontResource.DefaultFontName);
+        FluentUI = CreateInstance(FontResource.FluentUIName);
     }
 
     /// <summary>

--- a/Views/FontGlyphsView.xaml
+++ b/Views/FontGlyphsView.xaml
@@ -66,14 +66,15 @@
                               />
         </Grid>
 
-        <controls:Slider Grid.Row="0" 
-                         Grid.Column="1"
-                         Minimum="0"
-                         Maximum="{Binding MaxRow, Mode=OneWay}"
-                         Interval="1"
-                         Value="{Binding Row}"
-                         Orientation="Vertical"
-                         />
+        <controls:SliderView Grid.Row="0" 
+                             Grid.Column="1"
+                             Minimum="0" 
+                             Maximum="{Binding MaxRow}"
+                             Interval="1"
+                             Value="{Binding Row}"
+                             Orientation="Vertical"                           
+                             />
+
     </Grid>
 
 


### PR DESCRIPTION
This change adds previous and next buttons the FontGlyphsView slider via a SliderView ContentView that encapsulates the slider and previous/next buttons.

The SliderView defines a BindableProperty for selected Slider properties and relays them to the slider.

A Toolbar layout class facilities the layout of the SliderView.

Controls:
- Add generic Layout and LayoutManager
- Add Toolbar and ToolbarLayoutManager
- Add SliderView Converter:
- Add generic TypeConverter base class.

FontFamily:
- Rename DefaultFontFamily to Defauilt
- Rename FluentUIFontFamily to FluentUI

GlyphsView:
- Replace Slider with SliderView

SkLabel:
- Integrate FontFamily changes
- Fix #endregion labels

Slider:
- Fix OnPropertyChanged implementation.
- use Math.Clamp in ValueProperty coerceValue